### PR TITLE
Enable SQLite foreign key enforcement

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,8 @@ Issues identified during code review, ordered by estimated effort (least to most
 - [x] **Fix `total_changes` bug in `bulk_create`** — `services/transactions.py:140` uses `conn.total_changes` which counts all changes on the connection, not just the last `executemany`. Use `cursor.rowcount` instead.
   - **Plan**: Capture cursor from `conn.executemany(...)` and return `cursor.rowcount`. Add a test that verifies the count is correct when prior inserts exist on the same connection.
 
-- [ ] **Enable foreign key enforcement** — `db/manager.py:33` opens SQLite connections without `PRAGMA foreign_keys = ON`, so all FK constraints (cascading deletes, referential integrity) are silently unenforced.
+- [x] **Enable foreign key enforcement** — `db/manager.py:33` opens SQLite connections without `PRAGMA foreign_keys = ON`, so all FK constraints (cascading deletes, referential integrity) are silently unenforced.
+  - **Plan**: Add `PRAGMA foreign_keys = ON` to `DatabaseManager.connect()` and to the `test_db` fixture. Note: `transactions.account_id` has no CASCADE, so deleting an account with transactions will now correctly raise an error.
 
 ## Small changes
 

--- a/db/manager.py
+++ b/db/manager.py
@@ -31,6 +31,7 @@ class DatabaseManager:
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
         try:
             yield conn
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def test_db():
         sqlite3.Connection: Connection to in-memory database.
     """
     conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
     yield conn
     conn.close()
 

--- a/tests/services/test_transactions.py
+++ b/tests/services/test_transactions.py
@@ -1,5 +1,8 @@
+import sqlite3
 from datetime import date, timedelta
 from decimal import Decimal
+
+import pytest
 
 from models.transaction import Transaction
 
@@ -130,6 +133,26 @@ class TestTransactionService:
 
         # Should be exactly 2, not 7 (2 + 5 prior)
         assert count == 2
+
+    def test_create_transaction_with_invalid_account_raises_fk_error(self, services):
+        """FK enforcement: creating a transaction with a non-existent account_id raises IntegrityError."""
+        account = services.accounts.create("test_account", "bofa", "Test Account")
+        data_import = services.data_imports.create(account.id, "test.csv.gz")
+
+        transaction = Transaction.create_with_checksum(
+            raw_data="01/15/2025,STARBUCKS,-5.75,1000.00",
+            account_id=99999,  # does not exist
+            transaction_date=date(2025, 1, 15),
+            post_date=None,
+            description="STARBUCKS",
+            bank_category=None,
+            amount=Decimal("5.75"),
+            type="expense",
+        )
+        transaction.data_import_id = data_import.id
+
+        with pytest.raises(sqlite3.IntegrityError):
+            services.transactions.create(transaction)
 
     def test_find_transaction_by_id(self, services):
         """Test finding a transaction by ID."""


### PR DESCRIPTION
## Summary
- SQLite silently ignores FK constraints unless `PRAGMA foreign_keys = ON` is set per connection
- Added the PRAGMA to `DatabaseManager.connect()` in `db/manager.py` so all connections enforce referential integrity
- Updated the `test_db` fixture in `tests/conftest.py` to match, so tests run under production-equivalent constraints
- Added a test verifying that inserting a transaction with a non-existent `account_id` now raises `IntegrityError`

**Behavioral note**: `transactions.account_id` has no `ON DELETE CASCADE`, so deleting an account that has transactions will now correctly raise an error rather than leaving orphaned rows.

## References
TODO.md: "Enable foreign key enforcement"

## Test plan
- [x] All 236 tests pass with FK enforcement active
- [x] New test `test_create_transaction_with_invalid_account_raises_fk_error` confirms enforcement is live
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)