### PR TITLE
Remove dead Transaction.to_dict() method

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,8 @@ Issues identified during code review, ordered by estimated effort (least to most
 
 ## Small changes
 
-- [ ] **Remove dead `to_dict()` method** — `models/transaction.py:60` is unused (services build tuples directly), includes a stale `raw_data` field, and is missing newer fields like amortization and merchant name.
+- [x] **Remove dead `to_dict()` method** — `models/transaction.py:60` is unused (services build tuples directly), includes a stale `raw_data` field, and is missing newer fields like amortization and merchant name.
+  - **Plan**: Delete the method. No callers exist. No new tests needed; existing suite confirms nothing breaks.
 
 - [ ] **Rename `type` field on Transaction** — `models/transaction.py:18` shadows Python's builtin `type()`. Rename to `transaction_type` or similar across the codebase.
 

--- a/models/transaction.py
+++ b/models/transaction.py
@@ -3,7 +3,6 @@ from datetime import date
 from decimal import Decimal
 from typing import Optional
 import hashlib
-import json
 
 
 @dataclass
@@ -56,26 +55,3 @@ class Transaction:
             type=type,
             additional_metadata=additional_metadata,
         )
-
-    def to_dict(self) -> dict:
-        """Convert transaction to dictionary for database storage."""
-        return {
-            "id": self.id,
-            "account_id": self.account_id,
-            "transaction_date": self.transaction_date.isoformat(),
-            "post_date": self.post_date.isoformat() if self.post_date else None,
-            "description": self.description,
-            "bank_category": self.bank_category,
-            "category_id": self.category_id,
-            "auto_category_id": self.auto_category_id,
-            "merchant_name": self.merchant_name,
-            "auto_merchant_name": self.auto_merchant_name,
-            "amount": float(self.amount),
-            "transaction_type": self.type,
-            "raw_data": None,  # Will be set by ingestion module
-            "additional_metadata": (
-                json.dumps(self.additional_metadata)
-                if self.additional_metadata
-                else None
-            ),
-        }


### PR DESCRIPTION
## Summary
- Deleted `Transaction.to_dict()` from `models/transaction.py` — it had zero callers (services build tuples directly for DB inserts)
- The method also contained a stale `raw_data` field and was missing newer fields (amortization, merchant name), making it misleading to keep
- Removed the now-unused `json` import

## References
TODO.md: "Remove dead `to_dict()` method"

## Test plan
- [x] All 236 tests pass unchanged — confirms no callers existed

🤖 Generated with [Claude Code](https://claude.com/claude-code)