### PR TITLE
Rename Transaction.type to transaction_type

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,8 @@ Issues identified during code review, ordered by estimated effort (least to most
 - [x] **Remove dead `to_dict()` method** — `models/transaction.py:60` is unused (services build tuples directly), includes a stale `raw_data` field, and is missing newer fields like amortization and merchant name.
   - **Plan**: Delete the method. No callers exist. No new tests needed; existing suite confirms nothing breaks.
 
-- [ ] **Rename `type` field on Transaction** — `models/transaction.py:18` shadows Python's builtin `type()`. Rename to `transaction_type` or similar across the codebase.
+- [x] **Rename `type` field on Transaction** — `models/transaction.py:18` shadows Python's builtin `type()`. Rename to `transaction_type` or similar across the codebase.
+  - **Plan**: Rename field and `create_with_checksum` param from `type` to `transaction_type`. DB column is already named `transaction_type` — no migration needed. Update all call sites across ingestion, services, tools, llm, cli, and tests. `Account.type` is unrelated and unchanged.
 
 ## Moderate refactors
 

--- a/cli/transactions.py
+++ b/cli/transactions.py
@@ -326,7 +326,7 @@ def cmd_export(args, services):
                         t.merchant_name or "",
                         t.auto_merchant_name or "",
                         float(t.amount),
-                        t.type,
+                        t.transaction_type,
                         t.data_import_id,
                         t.amortize_months or "",
                         (

--- a/ingestion/amex.py
+++ b/ingestion/amex.py
@@ -98,7 +98,7 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
         description=description,
         bank_category=category if category else None,
         amount=amount,
-        type=transaction_type,
+        transaction_type=transaction_type,
         additional_metadata=additional_metadata if additional_metadata else None,
     )
 

--- a/ingestion/bofa.py
+++ b/ingestion/bofa.py
@@ -73,7 +73,7 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
         description=description,
         bank_category=None,  # BoFA CSV doesn't include category
         amount=amount,
-        type=transaction_type,
+        transaction_type=transaction_type,
         additional_metadata=additional_metadata,
     )
 

--- a/ingestion/bofacc.py
+++ b/ingestion/bofacc.py
@@ -67,7 +67,7 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
         description=payee,
         bank_category=None,  # BofA CC CSV doesn't include category
         amount=amount,
-        type=transaction_type,
+        transaction_type=transaction_type,
         additional_metadata=additional_metadata,
     )
 

--- a/ingestion/chase.py
+++ b/ingestion/chase.py
@@ -77,7 +77,7 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
         description=description,
         bank_category=category if category else None,
         amount=amount,
-        type=transaction_type,
+        transaction_type=transaction_type,
         additional_metadata=additional_metadata if additional_metadata else None,
     )
 

--- a/ingestion/discover.py
+++ b/ingestion/discover.py
@@ -64,7 +64,7 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
         description=description,
         bank_category=category if category else None,
         amount=amount,
-        type=transaction_type,
+        transaction_type=transaction_type,
         additional_metadata=None,
     )
 

--- a/llm/providers/openai.py
+++ b/llm/providers/openai.py
@@ -170,7 +170,7 @@ class OpenAIProvider(LLMProvider):
             lines.append(
                 f"- Description: '{txn.description}', "
                 f"Amount: ${txn.amount}, "
-                f"Type: {txn.type}, "
+                f"Type: {txn.transaction_type}, "
                 f"Category: {category_name} (ID {txn.category_id}){merchant_part}"
             )
 
@@ -184,7 +184,7 @@ class OpenAIProvider(LLMProvider):
                 f"- ID: {txn.id}, "
                 f"Description: '{txn.description}', "
                 f"Amount: ${txn.amount}, "
-                f"Type: {txn.type}"
+                f"Type: {txn.transaction_type}"
             )
 
         return "\n".join(lines)

--- a/models/transaction.py
+++ b/models/transaction.py
@@ -14,7 +14,7 @@ class Transaction:
     description: str
     bank_category: Optional[str]  # category from bank/CSV import
     amount: Decimal  # always positive
-    type: str  # 'income', 'expense', or 'transfer'
+    transaction_type: str  # 'income', 'expense', or 'transfer'
     additional_metadata: Optional[dict] = None
     data_import_id: int = (
         0  # reference to the data import operation (set during ingestion)
@@ -39,7 +39,7 @@ class Transaction:
         description: str,
         bank_category: Optional[str],
         amount: Decimal,
-        type: str,
+        transaction_type: str,
         additional_metadata: Optional[dict] = None,
     ) -> "Transaction":
         """Create a Transaction with auto-generated checksum ID."""
@@ -52,6 +52,6 @@ class Transaction:
             description=description,
             bank_category=bank_category,
             amount=amount,
-            type=type,
+            transaction_type=transaction_type,
             additional_metadata=additional_metadata,
         )

--- a/services/transactions.py
+++ b/services/transactions.py
@@ -67,7 +67,7 @@ class TransactionService:
                     transaction.merchant_name,
                     transaction.auto_merchant_name,
                     float(transaction.amount),
-                    transaction.type,
+                    transaction.transaction_type,
                     (
                         json.dumps(transaction.additional_metadata)
                         if transaction.additional_metadata
@@ -116,7 +116,7 @@ class TransactionService:
                     t.merchant_name,
                     t.auto_merchant_name,
                     float(t.amount),
-                    t.type,
+                    t.transaction_type,
                     json.dumps(t.additional_metadata)
                     if t.additional_metadata
                     else None,
@@ -469,7 +469,7 @@ class TransactionService:
                     description=original.description,
                     bank_category=original.bank_category,
                     amount=accrued_amount,
-                    type=original.type,
+                    transaction_type=original.transaction_type,
                     additional_metadata=original.additional_metadata,
                     data_import_id=original.data_import_id,
                     category_id=original.category_id,
@@ -493,7 +493,7 @@ class TransactionService:
             description=row[5],
             bank_category=row[6],
             amount=Decimal(str(row[11])),
-            type=row[12],
+            transaction_type=row[12],
             additional_metadata=json.loads(row[13]) if row[13] else None,
             data_import_id=row[2],
             category_id=row[7],

--- a/tests/ingestion/test_amex.py
+++ b/tests/ingestion/test_amex.py
@@ -33,7 +33,7 @@ class TestRowToTransaction:
         assert transaction.post_date is None  # AMEX doesn't have post date
         assert transaction.description == "AMAZON.COM"
         assert transaction.amount == Decimal("45.99")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
         assert transaction.bank_category == "Merchandise & Supplies-Internet Purchase"
         assert transaction.additional_metadata["appears_as"] == "AMAZON.COM*RETAIL"
         assert transaction.additional_metadata["address"] == "410 TERRY AVE N"
@@ -64,7 +64,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("500.00")
-        assert transaction.type == "income"
+        assert transaction.transaction_type == "income"
         assert transaction.bank_category == "Payments"
         # Empty metadata fields should not be included
         assert (
@@ -92,7 +92,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1250.00")
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
         assert transaction.description == "AUTOPAY PAYMENT - THANK YOU"
 
     def test_parse_amount_with_commas(self):
@@ -115,7 +115,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1234.56")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
         """Test parsing descriptions and categories with quotes."""
@@ -372,11 +372,11 @@ class TestIngest:
 
         assert len(transactions) == 3
         assert transactions[0].description == "STARBUCKS"
-        assert transactions[0].type == "expense"
+        assert transactions[0].transaction_type == "expense"
         assert transactions[1].description == "PAYMENT - THANK YOU"
-        assert transactions[1].type == "income"
+        assert transactions[1].transaction_type == "income"
         assert transactions[2].description == "AUTOPAY PAYMENT - THANK YOU"
-        assert transactions[2].type == "transfer"
+        assert transactions[2].transaction_type == "transfer"
 
     def test_ingest_with_full_metadata(self):
         """Test ingesting CSV with all metadata fields populated."""

--- a/tests/ingestion/test_bofa.py
+++ b/tests/ingestion/test_bofa.py
@@ -21,7 +21,7 @@ class TestRowToTransaction:
         assert transaction.post_date is None
         assert transaction.description == "STARBUCKS #12345"
         assert transaction.amount == Decimal("5.75")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
         assert transaction.bank_category is None
         assert transaction.additional_metadata == {"running_balance": "1,234.56"}
         assert isinstance(transaction.id, str)
@@ -35,7 +35,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("3500.00")
-        assert transaction.type == "income"
+        assert transaction.transaction_type == "income"
         assert transaction.description == "SALARY DEPOSIT"
 
     def test_parse_amount_with_commas(self):
@@ -46,7 +46,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1234.56")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
 
     def test_parse_amount_with_quotes(self):
         """Test parsing amounts and descriptions with quotes."""
@@ -70,7 +70,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
         assert transaction.amount == Decimal("150.00")
 
     def test_detect_chase_credit_card_transfer(self):
@@ -80,7 +80,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
 
     def test_detect_amex_credit_card_transfer(self):
         """Test detection of American Express payment as transfer."""
@@ -89,7 +89,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
 
     def test_detect_bofa_credit_card_transfer(self):
         """Test detection of Bank of America credit card payment as transfer."""
@@ -103,7 +103,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
         assert transaction.amount == Decimal("400.00")
 
     def test_missing_date_raises_error(self):
@@ -183,11 +183,11 @@ Date,Description,Amount,Running Bal.
 
         assert len(transactions) == 3
         assert transactions[0].description == "STARBUCKS"
-        assert transactions[0].type == "expense"
+        assert transactions[0].transaction_type == "expense"
         assert transactions[1].description == "SALARY DEPOSIT"
-        assert transactions[1].type == "income"
+        assert transactions[1].transaction_type == "income"
         assert transactions[2].description == "CHASE CREDIT CRD DES:AUTOPAY"
-        assert transactions[2].type == "transfer"
+        assert transactions[2].transaction_type == "transfer"
 
     def test_ingest_skips_malformed_rows(self):
         """Test that malformed rows are skipped gracefully."""

--- a/tests/ingestion/test_bofacc.py
+++ b/tests/ingestion/test_bofacc.py
@@ -27,7 +27,7 @@ class TestRowToTransaction:
         assert transaction.post_date is None
         assert transaction.description == "WHOLEFDS HAR 10221 OAKLAND CA"
         assert transaction.amount == Decimal("30.29")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
         assert transaction.bank_category is None
         assert transaction.additional_metadata == {
             "reference_number": "24137465045001942681814",
@@ -50,7 +50,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("60.00")
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
         assert transaction.description == "PAYMENT - THANK YOU"
 
     def test_parse_amount_with_commas(self):
@@ -67,7 +67,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1290.47")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
         """Test parsing payee and address with quotes."""
@@ -102,7 +102,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("0.88")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
 
     def test_parse_large_expense(self):
         """Test parsing large expense amounts."""
@@ -118,7 +118,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("2500.99")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
 
     def test_empty_address_field(self):
         """Test handling of empty address field."""
@@ -247,13 +247,13 @@ class TestIngest:
 
         assert len(transactions) == 3
         assert transactions[0].description == "WHOLEFDS HAR 10221 OAKLAND CA"
-        assert transactions[0].type == "expense"
+        assert transactions[0].transaction_type == "expense"
         assert transactions[0].amount == Decimal("30.29")
         assert transactions[1].description == "PAYMENT - THANK YOU"
-        assert transactions[1].type == "transfer"
+        assert transactions[1].transaction_type == "transfer"
         assert transactions[1].amount == Decimal("60.00")
         assert transactions[2].description == "NEWEGG MARKETPLACE 800-390-1119 CA"
-        assert transactions[2].type == "expense"
+        assert transactions[2].transaction_type == "expense"
         assert transactions[2].amount == Decimal("1290.47")
 
     def test_ingest_skips_malformed_rows(self):
@@ -364,9 +364,9 @@ class TestIngest:
         transactions = ingest(source, account_id)
 
         assert len(transactions) == 3
-        assert transactions[0].type == "expense"
-        assert transactions[1].type == "transfer"
-        assert transactions[2].type == "expense"
+        assert transactions[0].transaction_type == "expense"
+        assert transactions[1].transaction_type == "transfer"
+        assert transactions[2].transaction_type == "expense"
 
     def test_ingest_with_metadata(self):
         """Test that reference numbers and addresses are captured in metadata."""
@@ -408,10 +408,10 @@ class TestIngest:
         assert transactions[0].transaction_date == date(2025, 2, 14)
         assert transactions[0].description == "WHOLEFDS HAR 10221 OAKLAND CA"
         assert transactions[0].amount == Decimal("30.29")
-        assert transactions[0].type == "expense"
+        assert transactions[0].transaction_type == "expense"
         # Check payment transaction
         assert transactions[4].description == "PAYMENT - THANK YOU"
         assert transactions[4].amount == Decimal("60.00")
-        assert transactions[4].type == "transfer"
+        assert transactions[4].transaction_type == "transfer"
         # Check small amount transaction
         assert transactions[3].amount == Decimal("0.88")

--- a/tests/ingestion/test_chase.py
+++ b/tests/ingestion/test_chase.py
@@ -29,7 +29,7 @@ class TestRowToTransaction:
         assert transaction.post_date == date(2025, 1, 16)
         assert transaction.description == "AMAZON.COM"
         assert transaction.amount == Decimal("45.99")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
         assert transaction.bank_category == "Shopping"
         assert transaction.additional_metadata is None
         assert isinstance(transaction.id, str)
@@ -51,7 +51,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("50.00")
-        assert transaction.type == "income"
+        assert transaction.transaction_type == "income"
 
     def test_parse_transfer_payment_type(self):
         """Test parsing transaction with Type='Payment' as transfer."""
@@ -69,7 +69,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("500.00")
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
         assert transaction.description == "ONLINE PAYMENT"
 
     def test_parse_transfer_automatic_payment(self):
@@ -88,7 +88,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1250.00")
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
 
     def test_parse_with_memo(self):
         """Test parsing transaction with memo field."""
@@ -124,7 +124,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1234.56")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
         """Test parsing descriptions and categories with quotes."""
@@ -290,11 +290,11 @@ class TestIngest:
 
         assert len(transactions) == 3
         assert transactions[0].description == "STARBUCKS"
-        assert transactions[0].type == "expense"
+        assert transactions[0].transaction_type == "expense"
         assert transactions[1].description == "REFUND"
-        assert transactions[1].type == "income"
+        assert transactions[1].transaction_type == "income"
         assert transactions[2].description == "AUTOMATIC PAYMENT - THANK YOU"
-        assert transactions[2].type == "transfer"
+        assert transactions[2].transaction_type == "transfer"
 
     def test_ingest_skips_malformed_rows(self):
         """Test that malformed rows are skipped gracefully."""
@@ -403,9 +403,9 @@ class TestIngest:
         transactions = ingest(source, account_id)
 
         assert len(transactions) == 3
-        assert transactions[0].type == "expense"
-        assert transactions[1].type == "transfer"
-        assert transactions[2].type == "income"
+        assert transactions[0].transaction_type == "expense"
+        assert transactions[1].transaction_type == "transfer"
+        assert transactions[2].transaction_type == "income"
 
     def test_ingest_with_memos(self):
         """Test that memo fields are properly captured in metadata."""

--- a/tests/ingestion/test_discover.py
+++ b/tests/ingestion/test_discover.py
@@ -27,7 +27,7 @@ class TestRowToTransaction:
         assert transaction.post_date == date(2025, 1, 16)
         assert transaction.description == "AMAZON.COM"
         assert transaction.amount == Decimal("45.99")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
         assert transaction.bank_category == "Shopping"
         assert isinstance(transaction.id, str)
         assert len(transaction.id) == 64
@@ -46,7 +46,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("500.00")
-        assert transaction.type == "income"
+        assert transaction.transaction_type == "income"
         assert transaction.bank_category == "Payments and Credits"
 
     def test_parse_transfer_directpay(self):
@@ -63,7 +63,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1250.00")
-        assert transaction.type == "transfer"
+        assert transaction.transaction_type == "transfer"
         assert transaction.description == "DIRECTPAY FULL BALANCE"
 
     def test_parse_amount_with_commas(self):
@@ -80,7 +80,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.amount == Decimal("1234.56")
-        assert transaction.type == "expense"
+        assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
         """Test parsing descriptions and categories with quotes."""
@@ -184,11 +184,11 @@ class TestIngest:
 
         assert len(transactions) == 3
         assert transactions[0].description == "STARBUCKS"
-        assert transactions[0].type == "expense"
+        assert transactions[0].transaction_type == "expense"
         assert transactions[1].description == "PAYMENT THANK YOU"
-        assert transactions[1].type == "income"
+        assert transactions[1].transaction_type == "income"
         assert transactions[2].description == "DIRECTPAY FULL BALANCE"
-        assert transactions[2].type == "transfer"
+        assert transactions[2].transaction_type == "transfer"
 
     def test_ingest_skips_malformed_rows(self):
         """Test that malformed rows are skipped gracefully."""

--- a/tests/services/test_transactions.py
+++ b/tests/services/test_transactions.py
@@ -23,7 +23,7 @@ class TestTransactionService:
             description="STARBUCKS",
             bank_category=None,
             amount=Decimal("5.75"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
 
@@ -54,7 +54,7 @@ class TestTransactionService:
                 description=f"Transaction {i}",
                 bank_category=None,
                 amount=Decimal(str(i)),
-                type="expense",
+                transaction_type="expense",
             )
             for i in range(1, 4)
         ]
@@ -83,7 +83,7 @@ class TestTransactionService:
             description="DUPLICATE",
             bank_category=None,
             amount=Decimal("5.75"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
 
@@ -119,7 +119,7 @@ class TestTransactionService:
                 description=f"TX{i}",
                 bank_category=None,
                 amount=Decimal(f"{i}.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             return t
@@ -147,7 +147,7 @@ class TestTransactionService:
             description="STARBUCKS",
             bank_category=None,
             amount=Decimal("5.75"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
 
@@ -167,7 +167,7 @@ class TestTransactionService:
             description="FIND ME",
             bank_category=None,
             amount=Decimal("10.00"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
         services.transactions.create(transaction)
@@ -198,7 +198,7 @@ class TestTransactionService:
                 description=f"Transaction {i}",
                 bank_category=None,
                 amount=Decimal(str(i)),
-                type="expense",
+                transaction_type="expense",
             )
             for i in range(3)
         ]
@@ -237,7 +237,7 @@ class TestTransactionService:
             description="STORE",
             bank_category=None,
             amount=Decimal("50.00"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
         services.transactions.create(transaction)
@@ -264,7 +264,7 @@ class TestTransactionService:
             description="Fake",
             bank_category=None,
             amount=Decimal("10.00"),
-            type="expense",
+            transaction_type="expense",
         )
         fake_transaction.category_id = category.id
         result = services.transactions.update(fake_transaction, ["category_id"])
@@ -287,7 +287,7 @@ class TestTransactionService:
                 description=f"RESTAURANT{i}",
                 bank_category=None,
                 amount=Decimal("20.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -319,7 +319,7 @@ class TestTransactionService:
                 description=f"AUTO{i}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -348,7 +348,7 @@ class TestTransactionService:
             description="SUBSCRIPTION",
             bank_category=None,
             amount=Decimal("120.00"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
         services.transactions.create(transaction)
@@ -382,7 +382,7 @@ class TestTransactionService:
                 description=f"SUBSCRIPTION{i}",
                 bank_category=None,
                 amount=Decimal("100.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -417,7 +417,7 @@ class TestTransactionService:
                 description=f"Transaction {i}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -450,7 +450,7 @@ class TestTransactionService:
                 description=f"Transaction for {account.name}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -479,7 +479,7 @@ class TestTransactionService:
                 description=f"Transaction {i}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -514,7 +514,7 @@ class TestTransactionService:
                 description=f"Transaction {i}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -553,7 +553,7 @@ class TestTransactionService:
                 description=f"Transaction {i}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             t.category_id = category.id
@@ -584,7 +584,7 @@ class TestTransactionService:
             description="STORE",
             bank_category=None,
             amount=Decimal("50.00"),
-            type="expense",
+            transaction_type="expense",
             additional_metadata=metadata,
         )
         transaction.data_import_id = data_import.id
@@ -607,7 +607,7 @@ class TestTransactionService:
             description="PENDING",
             bank_category="Shopping",
             amount=Decimal("25.00"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
         services.transactions.create(transaction)
@@ -631,7 +631,7 @@ class TestTransactionService:
             description="Annual Subscription",
             bank_category=None,
             amount=Decimal("100.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.amortize_months = 12
@@ -646,7 +646,7 @@ class TestTransactionService:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         services.transactions.create(t2)
@@ -680,7 +680,7 @@ class TestTransactionService:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.category_id = category1.id
@@ -695,7 +695,7 @@ class TestTransactionService:
             description="Bus",
             bank_category=None,
             amount=Decimal("2.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         t2.category_id = category2.id
@@ -710,7 +710,7 @@ class TestTransactionService:
             description="Other",
             bank_category=None,
             amount=Decimal("3.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t3.data_import_id = data_import.id
         services.transactions.create(t3)
@@ -755,7 +755,7 @@ class TestTransactionService:
             description="Food Subscription",
             bank_category=None,
             amount=Decimal("100.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.category_id = category1.id
@@ -771,7 +771,7 @@ class TestTransactionService:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         t2.category_id = category1.id
@@ -802,7 +802,7 @@ class TestTransactionService:
             description="Subscription",
             bank_category=None,
             amount=Decimal("100.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.amortize_months = 12
@@ -817,7 +817,7 @@ class TestTransactionService:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         t2.category_id = category1.id
@@ -857,7 +857,7 @@ class TestTransactionService:
             description="Annual Subscription",
             bank_category=None,
             amount=Decimal("120.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.amortize_months = 12
@@ -891,7 +891,7 @@ class TestTransactionService:
             description="Subscription",
             bank_category=None,
             amount=Decimal("120.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.amortize_months = 12
@@ -928,7 +928,7 @@ class TestTransactionService:
             description="Quarterly",
             bank_category=None,
             amount=Decimal("100.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.amortize_months = 3
@@ -960,7 +960,7 @@ class TestTransactionService:
             description="Software",
             bank_category=None,
             amount=Decimal("120.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import1.id
         t1.category_id = category1.id
@@ -977,7 +977,7 @@ class TestTransactionService:
             description="Streaming",
             bank_category=None,
             amount=Decimal("60.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import2.id
         t2.category_id = category2.id
@@ -1023,7 +1023,7 @@ class TestTransactionService:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         services.transactions.create(t1)
@@ -1047,7 +1047,7 @@ class TestTransactionService:
             description="AMAZON.COM*123ABC",
             bank_category=None,
             amount=Decimal("25.00"),
-            type="expense",
+            transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
         transaction.merchant_name = "Amazon"
@@ -1075,7 +1075,7 @@ class TestTransactionService:
             description="AMAZON.COM",
             bank_category=None,
             amount=Decimal("25.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         services.transactions.create(t1)
@@ -1088,7 +1088,7 @@ class TestTransactionService:
             description="STARBUCKS",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         services.transactions.create(t2)
@@ -1121,7 +1121,7 @@ class TestTransactionService:
             description="WAL-MART #123",
             bank_category=None,
             amount=Decimal("50.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         services.transactions.create(t1)

--- a/tests/tools/test_transactions.py
+++ b/tests/tools/test_transactions.py
@@ -26,7 +26,7 @@ class TestGetPeriodTransactions:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.category_id = category.id
@@ -41,7 +41,7 @@ class TestGetPeriodTransactions:
             description="Annual Subscription",
             bank_category=None,
             amount=Decimal("120.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         t2.category_id = category.id
@@ -88,7 +88,7 @@ class TestGetPeriodTransactions:
                 description=f"Transaction {month}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -126,7 +126,7 @@ class TestGetPeriodTransactions:
                 description=f"Transaction {txn_date.month}",
                 bank_category=None,
                 amount=Decimal("10.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             services.transactions.create(t)
@@ -159,7 +159,7 @@ class TestGetPeriodTransactions:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.category_id = category1.id
@@ -174,7 +174,7 @@ class TestGetPeriodTransactions:
             description="Bus",
             bank_category=None,
             amount=Decimal("2.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         t2.category_id = category2.id
@@ -189,7 +189,7 @@ class TestGetPeriodTransactions:
             description="Food Subscription",
             bank_category=None,
             amount=Decimal("120.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t3.data_import_id = data_import.id
         t3.category_id = category1.id
@@ -228,7 +228,7 @@ class TestGetPeriodTransactions:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t.data_import_id = data_import.id
         services.transactions.create(t)
@@ -268,7 +268,7 @@ class TestGetPeriodTransactions:
             description="Quarterly Subscription",
             bank_category=None,
             amount=Decimal("300.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t.data_import_id = data_import.id
         t.amortize_months = 3
@@ -314,7 +314,7 @@ class TestGetPeriodSummary:
             description="Salary",
             bank_category=None,
             amount=Decimal("2000.00"),
-            type="income",
+            transaction_type="income",
         )
         t1.data_import_id = data_import.id
         services.transactions.create(t1)
@@ -328,7 +328,7 @@ class TestGetPeriodSummary:
             description="Groceries",
             bank_category=None,
             amount=Decimal("150.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         t2.category_id = category1.id
@@ -342,7 +342,7 @@ class TestGetPeriodSummary:
             description="Gas",
             bank_category=None,
             amount=Decimal("50.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t3.data_import_id = data_import.id
         t3.category_id = category2.id
@@ -377,7 +377,7 @@ class TestGetPeriodSummary:
             description="Mystery expense",
             bank_category=None,
             amount=Decimal("100.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t.data_import_id = data_import.id
         # No category_id set
@@ -409,7 +409,7 @@ class TestGetPeriodSummary:
                 description=f"Food {i}",
                 bank_category=None,
                 amount=Decimal("50.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             t.category_id = category.id
@@ -440,7 +440,7 @@ class TestGetPeriodSummary:
             description="Annual Subscription",
             bank_category=None,
             amount=Decimal("120.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t.data_import_id = data_import.id
         t.category_id = category.id
@@ -478,7 +478,7 @@ class TestGetPeriodSummary:
             description="Coffee",
             bank_category=None,
             amount=Decimal("5.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t.data_import_id = data_import.id
         services.transactions.create(t)
@@ -523,7 +523,7 @@ class TestGetPeriodSummary:
             description="Food",
             bank_category=None,
             amount=Decimal("100.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t1.data_import_id = data_import.id
         t1.category_id = category1.id
@@ -537,7 +537,7 @@ class TestGetPeriodSummary:
             description="Gas",
             bank_category=None,
             amount=Decimal("50.00"),
-            type="expense",
+            transaction_type="expense",
         )
         t2.data_import_id = data_import.id
         t2.category_id = category2.id
@@ -573,7 +573,7 @@ class TestGetPeriodSummary:
                 description=f"Food {month}",
                 bank_category=None,
                 amount=Decimal(f"{month * 100}.00"),
-                type="expense",
+                transaction_type="expense",
             )
             t.data_import_id = data_import.id
             t.category_id = category.id

--- a/tools/transactions.py
+++ b/tools/transactions.py
@@ -148,9 +148,9 @@ def get_period_summary(
 
             # Aggregate transactions
             for transaction in transactions:
-                if transaction.type == "income":
+                if transaction.transaction_type == "income":
                     income_total += transaction.amount
-                elif transaction.type == "expense":
+                elif transaction.transaction_type == "expense":
                     expense_total += transaction.amount
 
                     # Use category_id=0 for uncategorized transactions


### PR DESCRIPTION
## Summary
- `Transaction.type` shadowed Python's builtin `type()` — renamed to `transaction_type`
- The DB column was already named `transaction_type`, so no migration is needed
- Updated all call sites: model definition, `create_with_checksum` parameter, 5 ingestion modules, services, tools, LLM provider, CLI, and all tests
- `Account.type` is unrelated and was not changed

## References
TODO.md: "Rename `type` field on Transaction"

## Test plan
- [x] All 236 tests pass unchanged
- [x] Verified no stray `.type` references remain on Transaction objects
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)