### PR TITLE
Rename Account.type to account_type

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,9 @@ Issues identified during code review, ordered by estimated effort (least to most
 - [x] **Rename `type` field on Transaction** — `models/transaction.py:18` shadows Python's builtin `type()`. Rename to `transaction_type` or similar across the codebase.
   - **Plan**: Rename field and `create_with_checksum` param from `type` to `transaction_type`. DB column is already named `transaction_type` — no migration needed. Update all call sites across ingestion, services, tools, llm, cli, and tests. `Account.type` is unrelated and unchanged.
 
+- [x] **Rename `type` field on Account** — `models/account.py:8` also shadows Python's builtin `type()`. Rename to `account_type`.
+  - **Plan**: Add migration `009` to rename the DB column, rename field in model and `to_dict()`, update services, cli, and tests.
+
 ## Moderate refactors
 
 - [ ] **Fix N+1 queries in `cmd_update_from_csv`** — `cli/transactions.py:416` does a `find()` per CSV row, then updates each transaction individually at line 545. Should batch-fetch transactions and group updates by field set.

--- a/cli/accounts.py
+++ b/cli/accounts.py
@@ -20,7 +20,7 @@ def cmd_list(args, services):
     for account in accounts:
         logger.info(f"ID: {account.id}")
         logger.info(f"Name: {account.name}")
-        logger.info(f"Type: {account.type}")
+        logger.info(f"Type: {account.account_type}")
         logger.info(f"Description: {account.description}")
         logger.info("-" * 80)
 
@@ -62,7 +62,7 @@ def cmd_create(args, services):
 
         logger.info(f"\n✓ Account created successfully with ID: {account.id}")
         logger.info(f"  Name: {account.name}")
-        logger.info(f"  Type: {account.type}")
+        logger.info(f"  Type: {account.account_type}")
         logger.info(f"  Description: {account.description}")
 
     except Exception as e:

--- a/cli/transactions.py
+++ b/cli/transactions.py
@@ -36,13 +36,13 @@ def cmd_ingest(args, services):
     logger.info(
         f"Ingesting transactions for account: {account.name} (ID: {account.id})"
     )
-    logger.info(f"Account type: {account.type}")
+    logger.info(f"Account type: {account.account_type}")
     logger.info(f"CSV file: {args.csv_file}")
     logger.info("-" * 80)
 
     # Get the ingestion module for this account type
     try:
-        ingestion_module = get_ingestion_module(account.type)
+        ingestion_module = get_ingestion_module(account.account_type)
     except ValueError as e:
         logger.error(str(e))
         sys.exit(1)

--- a/db/migrations/009_rename_account_type_column.sql
+++ b/db/migrations/009_rename_account_type_column.sql
@@ -1,0 +1,2 @@
+-- Rename accounts.type to accounts.account_type to avoid shadowing Python's builtin type()
+ALTER TABLE accounts RENAME COLUMN type TO account_type;

--- a/models/account.py
+++ b/models/account.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 class Account:
     id: int
     name: str  # [a-z_] format, e.g., "bofa_checking"
-    type: str  # ingestion module name, e.g., "bofa"
+    account_type: str  # ingestion module name, e.g., "bofa"
     description: str  # human readable, e.g., "Bank of America Checking Account"
 
     def to_dict(self) -> dict:
@@ -13,6 +13,6 @@ class Account:
         return {
             "id": self.id,
             "name": self.name,
-            "type": self.type,
+            "account_type": self.account_type,
             "description": self.description,
         }

--- a/services/accounts.py
+++ b/services/accounts.py
@@ -23,12 +23,12 @@ class AccountService:
         """
         with self.db_manager.connect() as conn:
             cursor = conn.execute(
-                "SELECT id, name, type, description FROM accounts ORDER BY id"
+                "SELECT id, name, account_type, description FROM accounts ORDER BY id"
             )
             rows = cursor.fetchall()
 
             return [
-                Account(id=row[0], name=row[1], type=row[2], description=row[3])
+                Account(id=row[0], name=row[1], account_type=row[2], description=row[3])
                 for row in rows
             ]
 
@@ -43,13 +43,15 @@ class AccountService:
         """
         with self.db_manager.connect() as conn:
             cursor = conn.execute(
-                "SELECT id, name, type, description FROM accounts WHERE id = ?",
+                "SELECT id, name, account_type, description FROM accounts WHERE id = ?",
                 (account_id,),
             )
             row = cursor.fetchone()
 
             if row:
-                return Account(id=row[0], name=row[1], type=row[2], description=row[3])
+                return Account(
+                    id=row[0], name=row[1], account_type=row[2], description=row[3]
+                )
             return None
 
     def find_by_name(self, name: str) -> Optional[Account]:
@@ -63,13 +65,15 @@ class AccountService:
         """
         with self.db_manager.connect() as conn:
             cursor = conn.execute(
-                "SELECT id, name, type, description FROM accounts WHERE name = ?",
+                "SELECT id, name, account_type, description FROM accounts WHERE name = ?",
                 (name,),
             )
             row = cursor.fetchone()
 
             if row:
-                return Account(id=row[0], name=row[1], type=row[2], description=row[3])
+                return Account(
+                    id=row[0], name=row[1], account_type=row[2], description=row[3]
+                )
             return None
 
     def create(self, name: str, account_type: str, description: str) -> Account:
@@ -88,14 +92,17 @@ class AccountService:
         """
         with self.db_manager.connect() as conn:
             cursor = conn.execute(
-                "INSERT INTO accounts (name, type, description) VALUES (?, ?, ?)",
+                "INSERT INTO accounts (name, account_type, description) VALUES (?, ?, ?)",
                 (name, account_type, description),
             )
             conn.commit()
             account_id = cursor.lastrowid
 
             return Account(
-                id=account_id, name=name, type=account_type, description=description
+                id=account_id,
+                name=name,
+                account_type=account_type,
+                description=description,
             )
 
     def delete(self, account_id: int) -> bool:

--- a/tests/services/test_accounts.py
+++ b/tests/services/test_accounts.py
@@ -14,7 +14,7 @@ class TestAccountService:
         assert account.id is not None
         assert account.id > 0
         assert account.name == "bofa_checking"
-        assert account.type == "bofa"
+        assert account.account_type == "bofa"
         assert account.description == "Bank of America Checking"
 
     def test_find_account_by_id(self, services):
@@ -28,7 +28,7 @@ class TestAccountService:
         assert found is not None
         assert found.id == created.id
         assert found.name == "chase_card"
-        assert found.type == "chase"
+        assert found.account_type == "chase"
         assert found.description == "Chase Sapphire Card"
 
     def test_find_account_by_id_not_found(self, services):
@@ -47,7 +47,7 @@ class TestAccountService:
 
         assert found is not None
         assert found.name == "amex_card"
-        assert found.type == "amex"
+        assert found.account_type == "amex"
         assert found.description == "American Express Card"
 
     def test_find_by_name_not_found(self, services):
@@ -163,7 +163,7 @@ class TestAccountService:
         assert account_dict == {
             "id": account.id,
             "name": "test",
-            "type": "bofa",
+            "account_type": "bofa",
             "description": "Test Account",
         }
 
@@ -199,5 +199,5 @@ class TestAccountService:
         assert len(accounts) == 4
 
         # Verify all types are preserved
-        types = {acc.type for acc in accounts}
+        types = {acc.account_type for acc in accounts}
         assert types == {"bofa", "chase", "amex", "discover"}


### PR DESCRIPTION
## Summary
- `Account.type` shadowed Python's builtin `type()` — renamed to `account_type`
- Unlike `Transaction`, the DB column was named `type`, so migration `009` renames it to `account_type`
- Updated model definition, `to_dict()`, all SQL queries in services, CLI, and tests

## References
TODO.md: "Rename `type` field on Account"

## Test plan
- [x] All 236 tests pass with the migration applied
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)