### PR TITLE
Store transaction amounts as integers (cents)

### DIFF
--- a/cli/transactions.py
+++ b/cli/transactions.py
@@ -325,7 +325,7 @@ def cmd_export(args, services):
                         ),
                         t.merchant_name or "",
                         t.auto_merchant_name or "",
-                        float(t.amount),
+                        t.amount / 100,
                         t.transaction_type,
                         t.data_import_id,
                         t.amortize_months or "",
@@ -602,12 +602,12 @@ def cmd_set_amortization(args, services):
 
         logger.info("✓ Transaction amortization set successfully")
         logger.info(f"  Transaction: {transaction.description[:50]}...")
-        logger.info(f"  Amount: ${transaction.amount}")
+        logger.info(f"  Amount: ${transaction.amount / 100:.2f}")
         logger.info(f"  Amortize months: {months}")
         logger.info(
             f"  Amortization period: {transaction.transaction_date.isoformat()} to {amortize_end_date.isoformat()}"
         )
-        logger.info(f"  Monthly amount: ${float(transaction.amount) / months:.2f}")
+        logger.info(f"  Monthly amount: ${transaction.amount / months / 100:.2f}")
 
     except Exception as e:
         logger.error(f"Error updating transaction: {e}")

--- a/db/migrations/010_amount_to_integer.sql
+++ b/db/migrations/010_amount_to_integer.sql
@@ -1,0 +1,6 @@
+-- Migrate amount column from REAL to INTEGER (cents) to avoid floating-point rounding errors.
+-- $5.75 is stored as 575, $100.00 as 10000, etc.
+ALTER TABLE transactions RENAME COLUMN amount TO amount_real;
+ALTER TABLE transactions ADD COLUMN amount INTEGER NOT NULL DEFAULT 0;
+UPDATE transactions SET amount = CAST(ROUND(amount_real * 100) AS INTEGER);
+ALTER TABLE transactions DROP COLUMN amount_real;

--- a/ingestion/amex.py
+++ b/ingestion/amex.py
@@ -60,9 +60,9 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
     # Parse date (AMEX has only one date field)
     transaction_date = datetime.strptime(date_str, "%m/%d/%Y").date()
 
-    # Parse amount
+    # Parse amount and convert to integer cents
     amount_value = Decimal(amount_str.replace(",", ""))
-    amount = abs(amount_value)
+    amount = int(abs(amount_value) * 100)
 
     # Build additional metadata
     additional_metadata = {}

--- a/ingestion/bofa.py
+++ b/ingestion/bofa.py
@@ -39,12 +39,12 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
     # Parse date
     transaction_date = datetime.strptime(date_str, "%m/%d/%Y").date()
 
-    # Parse amount
+    # Parse amount and convert to integer cents
     if amount_str.startswith("-"):
-        amount = Decimal(amount_str[1:].replace(",", ""))
+        amount = int(Decimal(amount_str[1:].replace(",", "")) * 100)
         is_outgoing = True
     else:
-        amount = Decimal(amount_str.replace(",", ""))
+        amount = int(Decimal(amount_str.replace(",", "")) * 100)
         is_outgoing = False
 
     # Check for credit card payment transfers

--- a/ingestion/bofacc.py
+++ b/ingestion/bofacc.py
@@ -40,9 +40,9 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
     # Parse date
     transaction_date = datetime.strptime(posted_date_str, "%m/%d/%Y").date()
 
-    # Parse amount
+    # Parse amount and convert to integer cents
     amount_value = Decimal(amount_str.replace(",", ""))
-    amount = abs(amount_value)
+    amount = int(abs(amount_value) * 100)
 
     # Create additional metadata
     additional_metadata = {

--- a/ingestion/chase.py
+++ b/ingestion/chase.py
@@ -51,9 +51,9 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
     transaction_date = datetime.strptime(trans_date_str, "%m/%d/%Y").date()
     post_date = datetime.strptime(post_date_str, "%m/%d/%Y").date()
 
-    # Parse amount
+    # Parse amount and convert to integer cents
     amount_value = Decimal(amount_str.replace(",", ""))
-    amount = abs(amount_value)
+    amount = int(abs(amount_value) * 100)
 
     # Build additional metadata
     additional_metadata = {}

--- a/ingestion/discover.py
+++ b/ingestion/discover.py
@@ -41,9 +41,9 @@ def row_to_transaction(row: List[str], account_id: int) -> Transaction:
     transaction_date = datetime.strptime(trans_date_str, "%m/%d/%Y").date()
     post_date = datetime.strptime(post_date_str, "%m/%d/%Y").date()
 
-    # Parse amount and determine type
+    # Parse amount and convert to integer cents
     amount_value = Decimal(amount_str.replace(",", ""))
-    amount = abs(amount_value)
+    amount = int(abs(amount_value) * 100)
 
     # Check for credit card payment transfers
     if category == "Payments and Credits" and description.startswith(

--- a/models/transaction.py
+++ b/models/transaction.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal
 from typing import Optional
 import hashlib
 
@@ -13,7 +12,7 @@ class Transaction:
     post_date: Optional[date]
     description: str
     bank_category: Optional[str]  # category from bank/CSV import
-    amount: Decimal  # always positive
+    amount: int  # always positive, stored in cents (e.g. $5.75 → 575)
     transaction_type: str  # 'income', 'expense', or 'transfer'
     additional_metadata: Optional[dict] = None
     data_import_id: int = (
@@ -38,7 +37,7 @@ class Transaction:
         post_date: Optional[date],
         description: str,
         bank_category: Optional[str],
-        amount: Decimal,
+        amount: int,
         transaction_type: str,
         additional_metadata: Optional[dict] = None,
     ) -> "Transaction":

--- a/services/transactions.py
+++ b/services/transactions.py
@@ -4,7 +4,6 @@ import json
 import logging
 from typing import List, Optional
 from datetime import date
-from decimal import Decimal
 from models.transaction import Transaction
 
 logger = logging.getLogger(__name__)
@@ -69,7 +68,7 @@ class TransactionService:
                     transaction.auto_category_id,
                     transaction.merchant_name,
                     transaction.auto_merchant_name,
-                    float(transaction.amount),
+                    transaction.amount,
                     transaction.transaction_type,
                     (
                         json.dumps(transaction.additional_metadata)
@@ -148,7 +147,7 @@ class TransactionService:
                     t.auto_category_id,
                     t.merchant_name,
                     t.auto_merchant_name,
-                    float(t.amount),
+                    t.amount,
                     t.transaction_type,
                     json.dumps(t.additional_metadata)
                     if t.additional_metadata
@@ -490,8 +489,8 @@ class TransactionService:
             for row in rows:
                 original = self._row_to_transaction(row)
 
-                # Calculate accrued amount (rounded to 2 decimals)
-                accrued_amount = round(original.amount / original.amortize_months, 2)
+                # Calculate accrued amount in cents, rounded to nearest cent
+                accrued_amount = round(original.amount / original.amortize_months)
 
                 # Create new Transaction with accrued values
                 accrued_txn = Transaction(
@@ -525,7 +524,7 @@ class TransactionService:
             post_date=date.fromisoformat(row[4]) if row[4] else None,
             description=row[5],
             bank_category=row[6],
-            amount=Decimal(str(row[11])),
+            amount=row[11],
             transaction_type=row[12],
             additional_metadata=json.loads(row[13]) if row[13] else None,
             data_import_id=row[2],

--- a/tests/ingestion/test_amex.py
+++ b/tests/ingestion/test_amex.py
@@ -1,7 +1,6 @@
 import io
 import pytest
 from datetime import date
-from decimal import Decimal
 
 from ingestion.amex import row_to_transaction, ingest
 
@@ -32,7 +31,7 @@ class TestRowToTransaction:
         assert transaction.transaction_date == date(2025, 1, 15)
         assert transaction.post_date is None  # AMEX doesn't have post date
         assert transaction.description == "AMAZON.COM"
-        assert transaction.amount == Decimal("45.99")
+        assert transaction.amount == 4599
         assert transaction.transaction_type == "expense"
         assert transaction.bank_category == "Merchandise & Supplies-Internet Purchase"
         assert transaction.additional_metadata["appears_as"] == "AMAZON.COM*RETAIL"
@@ -63,7 +62,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("500.00")
+        assert transaction.amount == 50000
         assert transaction.transaction_type == "income"
         assert transaction.bank_category == "Payments"
         # Empty metadata fields should not be included
@@ -91,7 +90,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1250.00")
+        assert transaction.amount == 125000
         assert transaction.transaction_type == "transfer"
         assert transaction.description == "AUTOPAY PAYMENT - THANK YOU"
 
@@ -114,7 +113,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1234.56")
+        assert transaction.amount == 123456
         assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
@@ -222,7 +221,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.description == "MINIMAL"
-        assert transaction.amount == Decimal("50.00")
+        assert transaction.amount == 5000
         assert transaction.bank_category is None
         assert (
             transaction.additional_metadata is None
@@ -489,9 +488,9 @@ class TestIngest:
         transactions = ingest(source, account_id)
 
         assert len(transactions) == 3
-        assert transactions[0].amount == Decimal("5.00")
-        assert transactions[1].amount == Decimal("1234.56")
-        assert transactions[2].amount == Decimal("10000.00")
+        assert transactions[0].amount == 500
+        assert transactions[1].amount == 123456
+        assert transactions[2].amount == 1000000
 
     def test_ingest_with_various_categories(self):
         """Test that different categories are properly captured."""

--- a/tests/ingestion/test_bofa.py
+++ b/tests/ingestion/test_bofa.py
@@ -1,7 +1,6 @@
 import io
 import pytest
 from datetime import date
-from decimal import Decimal
 
 from ingestion.bofa import row_to_transaction, ingest
 
@@ -20,7 +19,7 @@ class TestRowToTransaction:
         assert transaction.transaction_date == date(2025, 1, 15)
         assert transaction.post_date is None
         assert transaction.description == "STARBUCKS #12345"
-        assert transaction.amount == Decimal("5.75")
+        assert transaction.amount == 575
         assert transaction.transaction_type == "expense"
         assert transaction.bank_category is None
         assert transaction.additional_metadata == {"running_balance": "1,234.56"}
@@ -34,7 +33,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("3500.00")
+        assert transaction.amount == 350000
         assert transaction.transaction_type == "income"
         assert transaction.description == "SALARY DEPOSIT"
 
@@ -45,7 +44,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1234.56")
+        assert transaction.amount == 123456
         assert transaction.transaction_type == "expense"
 
     def test_parse_amount_with_quotes(self):
@@ -56,7 +55,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.description == "QUOTED DESCRIPTION"
-        assert transaction.amount == Decimal("100.00")
+        assert transaction.amount == 10000
 
     def test_detect_discover_credit_card_transfer(self):
         """Test detection of Discover credit card payment as transfer."""
@@ -71,7 +70,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.transaction_type == "transfer"
-        assert transaction.amount == Decimal("150.00")
+        assert transaction.amount == 15000
 
     def test_detect_chase_credit_card_transfer(self):
         """Test detection of Chase credit card payment as transfer."""
@@ -104,7 +103,7 @@ class TestRowToTransaction:
         transaction = row_to_transaction(row, account_id)
 
         assert transaction.transaction_type == "transfer"
-        assert transaction.amount == Decimal("400.00")
+        assert transaction.amount == 40000
 
     def test_missing_date_raises_error(self):
         """Test that missing date field raises ValueError."""
@@ -302,6 +301,6 @@ Date,Description,Amount,Running Bal.
         transactions = ingest(source, account_id)
 
         assert len(transactions) == 3
-        assert transactions[0].amount == Decimal("5.00")
-        assert transactions[1].amount == Decimal("1234.56")
-        assert transactions[2].amount == Decimal("10000.00")
+        assert transactions[0].amount == 500
+        assert transactions[1].amount == 123456
+        assert transactions[2].amount == 1000000

--- a/tests/ingestion/test_bofacc.py
+++ b/tests/ingestion/test_bofacc.py
@@ -1,7 +1,6 @@
 import io
 import pytest
 from datetime import date
-from decimal import Decimal
 
 from ingestion.bofacc import row_to_transaction, ingest
 
@@ -26,7 +25,7 @@ class TestRowToTransaction:
         assert transaction.transaction_date == date(2025, 2, 14)
         assert transaction.post_date is None
         assert transaction.description == "WHOLEFDS HAR 10221 OAKLAND CA"
-        assert transaction.amount == Decimal("30.29")
+        assert transaction.amount == 3029
         assert transaction.transaction_type == "expense"
         assert transaction.bank_category is None
         assert transaction.additional_metadata == {
@@ -49,7 +48,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("60.00")
+        assert transaction.amount == 6000
         assert transaction.transaction_type == "transfer"
         assert transaction.description == "PAYMENT - THANK YOU"
 
@@ -66,7 +65,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1290.47")
+        assert transaction.amount == 129047
         assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
@@ -101,7 +100,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("0.88")
+        assert transaction.amount == 88
         assert transaction.transaction_type == "expense"
 
     def test_parse_large_expense(self):
@@ -117,7 +116,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("2500.99")
+        assert transaction.amount == 250099
         assert transaction.transaction_type == "expense"
 
     def test_empty_address_field(self):
@@ -248,13 +247,13 @@ class TestIngest:
         assert len(transactions) == 3
         assert transactions[0].description == "WHOLEFDS HAR 10221 OAKLAND CA"
         assert transactions[0].transaction_type == "expense"
-        assert transactions[0].amount == Decimal("30.29")
+        assert transactions[0].amount == 3029
         assert transactions[1].description == "PAYMENT - THANK YOU"
         assert transactions[1].transaction_type == "transfer"
-        assert transactions[1].amount == Decimal("60.00")
+        assert transactions[1].amount == 6000
         assert transactions[2].description == "NEWEGG MARKETPLACE 800-390-1119 CA"
         assert transactions[2].transaction_type == "expense"
-        assert transactions[2].amount == Decimal("1290.47")
+        assert transactions[2].amount == 129047
 
     def test_ingest_skips_malformed_rows(self):
         """Test that malformed rows are skipped gracefully."""
@@ -347,9 +346,9 @@ class TestIngest:
         transactions = ingest(source, account_id)
 
         assert len(transactions) == 3
-        assert transactions[0].amount == Decimal("5.00")
-        assert transactions[1].amount == Decimal("1234.56")
-        assert transactions[2].amount == Decimal("10000.00")
+        assert transactions[0].amount == 500
+        assert transactions[1].amount == 123456
+        assert transactions[2].amount == 1000000
 
     def test_ingest_mixed_transaction_types(self):
         """Test that expenses and payments are correctly identified."""
@@ -407,11 +406,11 @@ class TestIngest:
         # Check first transaction
         assert transactions[0].transaction_date == date(2025, 2, 14)
         assert transactions[0].description == "WHOLEFDS HAR 10221 OAKLAND CA"
-        assert transactions[0].amount == Decimal("30.29")
+        assert transactions[0].amount == 3029
         assert transactions[0].transaction_type == "expense"
         # Check payment transaction
         assert transactions[4].description == "PAYMENT - THANK YOU"
-        assert transactions[4].amount == Decimal("60.00")
+        assert transactions[4].amount == 6000
         assert transactions[4].transaction_type == "transfer"
         # Check small amount transaction
-        assert transactions[3].amount == Decimal("0.88")
+        assert transactions[3].amount == 88

--- a/tests/ingestion/test_chase.py
+++ b/tests/ingestion/test_chase.py
@@ -1,7 +1,6 @@
 import io
 import pytest
 from datetime import date
-from decimal import Decimal
 
 from ingestion.chase import row_to_transaction, ingest
 
@@ -28,7 +27,7 @@ class TestRowToTransaction:
         assert transaction.transaction_date == date(2025, 1, 15)
         assert transaction.post_date == date(2025, 1, 16)
         assert transaction.description == "AMAZON.COM"
-        assert transaction.amount == Decimal("45.99")
+        assert transaction.amount == 4599
         assert transaction.transaction_type == "expense"
         assert transaction.bank_category == "Shopping"
         assert transaction.additional_metadata is None
@@ -50,7 +49,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("50.00")
+        assert transaction.amount == 5000
         assert transaction.transaction_type == "income"
 
     def test_parse_transfer_payment_type(self):
@@ -68,7 +67,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("500.00")
+        assert transaction.amount == 50000
         assert transaction.transaction_type == "transfer"
         assert transaction.description == "ONLINE PAYMENT"
 
@@ -87,7 +86,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1250.00")
+        assert transaction.amount == 125000
         assert transaction.transaction_type == "transfer"
 
     def test_parse_with_memo(self):
@@ -105,7 +104,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("100.50")
+        assert transaction.amount == 10050
         assert transaction.additional_metadata == {"memo": "Weekly shopping"}
 
     def test_parse_amount_with_commas(self):
@@ -123,7 +122,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1234.56")
+        assert transaction.amount == 123456
         assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
@@ -386,9 +385,9 @@ class TestIngest:
         transactions = ingest(source, account_id)
 
         assert len(transactions) == 3
-        assert transactions[0].amount == Decimal("5.00")
-        assert transactions[1].amount == Decimal("1234.56")
-        assert transactions[2].amount == Decimal("10000.00")
+        assert transactions[0].amount == 500
+        assert transactions[1].amount == 123456
+        assert transactions[2].amount == 1000000
 
     def test_ingest_with_various_transaction_types(self):
         """Test that different type fields are handled correctly."""

--- a/tests/ingestion/test_discover.py
+++ b/tests/ingestion/test_discover.py
@@ -1,7 +1,6 @@
 import io
 import pytest
 from datetime import date
-from decimal import Decimal
 
 from ingestion.discover import row_to_transaction, ingest
 
@@ -26,7 +25,7 @@ class TestRowToTransaction:
         assert transaction.transaction_date == date(2025, 1, 15)
         assert transaction.post_date == date(2025, 1, 16)
         assert transaction.description == "AMAZON.COM"
-        assert transaction.amount == Decimal("45.99")
+        assert transaction.amount == 4599
         assert transaction.transaction_type == "expense"
         assert transaction.bank_category == "Shopping"
         assert isinstance(transaction.id, str)
@@ -45,7 +44,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("500.00")
+        assert transaction.amount == 50000
         assert transaction.transaction_type == "income"
         assert transaction.bank_category == "Payments and Credits"
 
@@ -62,7 +61,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1250.00")
+        assert transaction.amount == 125000
         assert transaction.transaction_type == "transfer"
         assert transaction.description == "DIRECTPAY FULL BALANCE"
 
@@ -79,7 +78,7 @@ class TestRowToTransaction:
 
         transaction = row_to_transaction(row, account_id)
 
-        assert transaction.amount == Decimal("1234.56")
+        assert transaction.amount == 123456
         assert transaction.transaction_type == "expense"
 
     def test_parse_with_quotes(self):
@@ -280,9 +279,9 @@ class TestIngest:
         transactions = ingest(source, account_id)
 
         assert len(transactions) == 3
-        assert transactions[0].amount == Decimal("5.00")
-        assert transactions[1].amount == Decimal("1234.56")
-        assert transactions[2].amount == Decimal("10000.00")
+        assert transactions[0].amount == 500
+        assert transactions[1].amount == 123456
+        assert transactions[2].amount == 1000000
 
     def test_ingest_with_various_categories(self):
         """Test that different categories are properly captured."""

--- a/tests/services/test_transactions.py
+++ b/tests/services/test_transactions.py
@@ -1,6 +1,5 @@
 import sqlite3
 from datetime import date, timedelta
-from decimal import Decimal
 
 import pytest
 
@@ -22,7 +21,7 @@ class TestTransactionService:
             post_date=None,
             description="STARBUCKS",
             bank_category=None,
-            amount=Decimal("5.75"),
+            amount=575,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -32,7 +31,7 @@ class TestTransactionService:
         assert created.id == transaction.id
         assert created.account_id == account.id
         assert created.description == "STARBUCKS"
-        assert created.amount == Decimal("5.75")
+        assert created.amount == 575
 
     def test_bulk_create_empty_list(self, services):
         """Test bulk creating with empty list returns 0."""
@@ -53,7 +52,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"Transaction {i}",
                 bank_category=None,
-                amount=Decimal(str(i)),
+                amount=i * 100,
                 transaction_type="expense",
             )
             for i in range(1, 4)
@@ -82,7 +81,7 @@ class TestTransactionService:
             post_date=None,
             description="DUPLICATE",
             bank_category=None,
-            amount=Decimal("5.75"),
+            amount=575,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -118,7 +117,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"TX{i}",
                 bank_category=None,
-                amount=Decimal(f"{i}.00"),
+                amount=i * 100,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -149,7 +148,7 @@ class TestTransactionService:
                 post_date=None,
                 description=description,
                 bank_category=None,
-                amount=Decimal("4.50"),
+                amount=450,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -184,7 +183,7 @@ class TestTransactionService:
             post_date=None,
             description="STARBUCKS",
             bank_category=None,
-            amount=Decimal("5.75"),
+            amount=575,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -204,7 +203,7 @@ class TestTransactionService:
             post_date=None,
             description="FIND ME",
             bank_category=None,
-            amount=Decimal("10.00"),
+            amount=1000,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -235,7 +234,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"Transaction {i}",
                 bank_category=None,
-                amount=Decimal(str(i)),
+                amount=i * 100,
                 transaction_type="expense",
             )
             for i in range(3)
@@ -274,7 +273,7 @@ class TestTransactionService:
             post_date=None,
             description="STORE",
             bank_category=None,
-            amount=Decimal("50.00"),
+            amount=5000,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -301,7 +300,7 @@ class TestTransactionService:
             post_date=None,
             description="Fake",
             bank_category=None,
-            amount=Decimal("10.00"),
+            amount=1000,
             transaction_type="expense",
         )
         fake_transaction.category_id = category.id
@@ -324,7 +323,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"RESTAURANT{i}",
                 bank_category=None,
-                amount=Decimal("20.00"),
+                amount=2000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -356,7 +355,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"AUTO{i}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -385,7 +384,7 @@ class TestTransactionService:
             post_date=None,
             description="SUBSCRIPTION",
             bank_category=None,
-            amount=Decimal("120.00"),
+            amount=12000,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -419,7 +418,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"SUBSCRIPTION{i}",
                 bank_category=None,
-                amount=Decimal("100.00"),
+                amount=10000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -454,7 +453,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"Transaction {i}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -487,7 +486,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"Transaction for {account.name}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -516,7 +515,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"Transaction {i}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -551,7 +550,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"Transaction {i}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -590,7 +589,7 @@ class TestTransactionService:
                 post_date=None,
                 description=f"Transaction {i}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -621,7 +620,7 @@ class TestTransactionService:
             post_date=None,
             description="STORE",
             bank_category=None,
-            amount=Decimal("50.00"),
+            amount=5000,
             transaction_type="expense",
             additional_metadata=metadata,
         )
@@ -644,7 +643,7 @@ class TestTransactionService:
             post_date=date(2025, 1, 16),
             description="PENDING",
             bank_category="Shopping",
-            amount=Decimal("25.00"),
+            amount=2500,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -668,7 +667,7 @@ class TestTransactionService:
             post_date=None,
             description="Annual Subscription",
             bank_category=None,
-            amount=Decimal("100.00"),
+            amount=10000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -683,7 +682,7 @@ class TestTransactionService:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -717,7 +716,7 @@ class TestTransactionService:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -732,7 +731,7 @@ class TestTransactionService:
             post_date=None,
             description="Bus",
             bank_category=None,
-            amount=Decimal("2.00"),
+            amount=200,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -747,7 +746,7 @@ class TestTransactionService:
             post_date=None,
             description="Other",
             bank_category=None,
-            amount=Decimal("3.00"),
+            amount=300,
             transaction_type="expense",
         )
         t3.data_import_id = data_import.id
@@ -792,7 +791,7 @@ class TestTransactionService:
             post_date=None,
             description="Food Subscription",
             bank_category=None,
-            amount=Decimal("100.00"),
+            amount=10000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -808,7 +807,7 @@ class TestTransactionService:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -839,7 +838,7 @@ class TestTransactionService:
             post_date=None,
             description="Subscription",
             bank_category=None,
-            amount=Decimal("100.00"),
+            amount=10000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -854,7 +853,7 @@ class TestTransactionService:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -894,7 +893,7 @@ class TestTransactionService:
             post_date=None,
             description="Annual Subscription",
             bank_category=None,
-            amount=Decimal("120.00"),
+            amount=12000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -907,7 +906,7 @@ class TestTransactionService:
 
         assert len(accrued) == 1
         assert accrued[0].id == t1.id
-        assert accrued[0].amount == Decimal("10.00")  # 120 / 12 = 10
+        assert accrued[0].amount == 1000  # 12000 / 12 = 1000
         assert accrued[0].transaction_date == date(2024, 7, 1)  # Start of month
         assert accrued[0].accrued is True
         assert accrued[0].description == "Annual Subscription"
@@ -928,7 +927,7 @@ class TestTransactionService:
             post_date=None,
             description="Subscription",
             bank_category=None,
-            amount=Decimal("120.00"),
+            amount=12000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -951,13 +950,13 @@ class TestTransactionService:
         assert len(jan_2025_accrued) == 0
 
     def test_get_accrued_transactions_by_month_amount_rounding(self, services):
-        """Test that accrued amounts are rounded to 2 decimals."""
+        """Test that accrued amounts are rounded to nearest cent."""
         from dateutil.relativedelta import relativedelta
 
         account = services.accounts.create("test_account", "bofa", "Test Account")
         data_import = services.data_imports.create(account.id, "test.csv.gz")
 
-        # Amount that doesn't divide evenly: 100 / 3 = 33.333...
+        # Amount that doesn't divide evenly: 10000 cents / 3 = 3333.33...
         t1 = Transaction.create_with_checksum(
             raw_data="01/01/2024,Quarterly,-100.00,1000.00",
             account_id=account.id,
@@ -965,7 +964,7 @@ class TestTransactionService:
             post_date=None,
             description="Quarterly",
             bank_category=None,
-            amount=Decimal("100.00"),
+            amount=10000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -976,7 +975,7 @@ class TestTransactionService:
         accrued = services.transactions.get_accrued_transactions_by_month(2024, 1)
 
         assert len(accrued) == 1
-        assert accrued[0].amount == Decimal("33.33")  # Rounded to 2 decimals
+        assert accrued[0].amount == 3333  # round(10000 / 3) = 3333
 
     def test_get_accrued_transactions_by_month_with_filters(self, services):
         """Test filtering accrued transactions by account and category."""
@@ -997,7 +996,7 @@ class TestTransactionService:
             post_date=None,
             description="Software",
             bank_category=None,
-            amount=Decimal("120.00"),
+            amount=12000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import1.id
@@ -1014,7 +1013,7 @@ class TestTransactionService:
             post_date=None,
             description="Streaming",
             bank_category=None,
-            amount=Decimal("60.00"),
+            amount=6000,
             transaction_type="expense",
         )
         t2.data_import_id = data_import2.id
@@ -1060,7 +1059,7 @@ class TestTransactionService:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -1084,7 +1083,7 @@ class TestTransactionService:
             post_date=None,
             description="AMAZON.COM*123ABC",
             bank_category=None,
-            amount=Decimal("25.00"),
+            amount=2500,
             transaction_type="expense",
         )
         transaction.data_import_id = data_import.id
@@ -1112,7 +1111,7 @@ class TestTransactionService:
             post_date=None,
             description="AMAZON.COM",
             bank_category=None,
-            amount=Decimal("25.00"),
+            amount=2500,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -1125,7 +1124,7 @@ class TestTransactionService:
             post_date=None,
             description="STARBUCKS",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -1158,7 +1157,7 @@ class TestTransactionService:
             post_date=None,
             description="WAL-MART #123",
             bank_category=None,
-            amount=Decimal("50.00"),
+            amount=5000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id

--- a/tests/tools/test_transactions.py
+++ b/tests/tools/test_transactions.py
@@ -1,7 +1,6 @@
 """Tests for transaction analysis tools."""
 
 from datetime import date
-from decimal import Decimal
 from dateutil.relativedelta import relativedelta
 
 from models.transaction import Transaction
@@ -25,7 +24,7 @@ class TestGetPeriodTransactions:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -40,7 +39,7 @@ class TestGetPeriodTransactions:
             post_date=None,
             description="Annual Subscription",
             bank_category=None,
-            amount=Decimal("120.00"),
+            amount=12000,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -70,7 +69,7 @@ class TestGetPeriodTransactions:
         accrual_basis = result["accrual_basis"]["2024/01"]
         assert len(accrual_basis) == 1
         assert accrual_basis[0].description == "Annual Subscription"
-        assert accrual_basis[0].amount == Decimal("10.00")
+        assert accrual_basis[0].amount == 1000
         assert accrual_basis[0].accrued is True
 
     def test_multi_month_period(self, services):
@@ -87,7 +86,7 @@ class TestGetPeriodTransactions:
                 post_date=None,
                 description=f"Transaction {month}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -125,7 +124,7 @@ class TestGetPeriodTransactions:
                 post_date=None,
                 description=f"Transaction {txn_date.month}",
                 bank_category=None,
-                amount=Decimal("10.00"),
+                amount=1000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -158,7 +157,7 @@ class TestGetPeriodTransactions:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -173,7 +172,7 @@ class TestGetPeriodTransactions:
             post_date=None,
             description="Bus",
             bank_category=None,
-            amount=Decimal("2.00"),
+            amount=200,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -188,7 +187,7 @@ class TestGetPeriodTransactions:
             post_date=None,
             description="Food Subscription",
             bank_category=None,
-            amount=Decimal("120.00"),
+            amount=12000,
             transaction_type="expense",
         )
         t3.data_import_id = data_import.id
@@ -227,7 +226,7 @@ class TestGetPeriodTransactions:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t.data_import_id = data_import.id
@@ -267,7 +266,7 @@ class TestGetPeriodTransactions:
             post_date=None,
             description="Quarterly Subscription",
             bank_category=None,
-            amount=Decimal("300.00"),
+            amount=30000,
             transaction_type="expense",
         )
         t.data_import_id = data_import.id
@@ -284,13 +283,13 @@ class TestGetPeriodTransactions:
 
         # Accrual should appear in Jan, Feb, Mar but not Apr
         assert len(result["accrual_basis"]["2024/01"]) == 1
-        assert result["accrual_basis"]["2024/01"][0].amount == Decimal("100.00")
+        assert result["accrual_basis"]["2024/01"][0].amount == 10000
 
         assert len(result["accrual_basis"]["2024/02"]) == 1
-        assert result["accrual_basis"]["2024/02"][0].amount == Decimal("100.00")
+        assert result["accrual_basis"]["2024/02"][0].amount == 10000
 
         assert len(result["accrual_basis"]["2024/03"]) == 1
-        assert result["accrual_basis"]["2024/03"][0].amount == Decimal("100.00")
+        assert result["accrual_basis"]["2024/03"][0].amount == 10000
 
         assert len(result["accrual_basis"]["2024/04"]) == 0
 
@@ -313,7 +312,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Salary",
             bank_category=None,
-            amount=Decimal("2000.00"),
+            amount=200000,
             transaction_type="income",
         )
         t1.data_import_id = data_import.id
@@ -327,7 +326,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Groceries",
             bank_category=None,
-            amount=Decimal("150.00"),
+            amount=15000,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -341,7 +340,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Gas",
             bank_category=None,
-            amount=Decimal("50.00"),
+            amount=5000,
             transaction_type="expense",
         )
         t3.data_import_id = data_import.id
@@ -357,11 +356,11 @@ class TestGetPeriodSummary:
 
         # Check cash basis summary
         summary = result["cash_basis"]["2024/01"]
-        assert summary["income_total"] == Decimal("2000.00")
-        assert summary["expense_total"] == Decimal("200.00")
-        assert summary["net"] == Decimal("1800.00")
-        assert summary["expenses_by_category"][category1.id] == Decimal("150.00")
-        assert summary["expenses_by_category"][category2.id] == Decimal("50.00")
+        assert summary["income_total"] == 200000
+        assert summary["expense_total"] == 20000
+        assert summary["net"] == 180000
+        assert summary["expenses_by_category"][category1.id] == 15000
+        assert summary["expenses_by_category"][category2.id] == 5000
 
     def test_uncategorized_expenses(self, services):
         """Test that uncategorized expenses use category_id=0."""
@@ -376,7 +375,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Mystery expense",
             bank_category=None,
-            amount=Decimal("100.00"),
+            amount=10000,
             transaction_type="expense",
         )
         t.data_import_id = data_import.id
@@ -390,8 +389,8 @@ class TestGetPeriodSummary:
         )
 
         summary = result["cash_basis"]["2024/01"]
-        assert summary["expense_total"] == Decimal("100.00")
-        assert summary["expenses_by_category"][0] == Decimal("100.00")
+        assert summary["expense_total"] == 10000
+        assert summary["expenses_by_category"][0] == 10000
 
     def test_multiple_expenses_same_category(self, services):
         """Test that multiple expenses in the same category are summed."""
@@ -408,7 +407,7 @@ class TestGetPeriodSummary:
                 post_date=None,
                 description=f"Food {i}",
                 bank_category=None,
-                amount=Decimal("50.00"),
+                amount=5000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -422,8 +421,8 @@ class TestGetPeriodSummary:
         )
 
         summary = result["cash_basis"]["2024/01"]
-        assert summary["expense_total"] == Decimal("150.00")
-        assert summary["expenses_by_category"][category.id] == Decimal("150.00")
+        assert summary["expense_total"] == 15000
+        assert summary["expenses_by_category"][category.id] == 15000
 
     def test_accrual_basis_summary(self, services):
         """Test summary for accrual basis with amortized transactions."""
@@ -439,7 +438,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Annual Subscription",
             bank_category=None,
-            amount=Decimal("120.00"),
+            amount=12000,
             transaction_type="expense",
         )
         t.data_import_id = data_import.id
@@ -456,13 +455,13 @@ class TestGetPeriodSummary:
 
         # Cash basis should be empty (transaction is amortized)
         cash_summary = result["cash_basis"]["2024/01"]
-        assert cash_summary["expense_total"] == Decimal("0")
+        assert cash_summary["expense_total"] == 0
         assert len(cash_summary["expenses_by_category"]) == 0
 
         # Accrual basis should show monthly amount
         accrual_summary = result["accrual_basis"]["2024/01"]
-        assert accrual_summary["expense_total"] == Decimal("10.00")
-        assert accrual_summary["expenses_by_category"][category.id] == Decimal("10.00")
+        assert accrual_summary["expense_total"] == 1000
+        assert accrual_summary["expenses_by_category"][category.id] == 1000
 
     def test_empty_month_summary(self, services):
         """Test that empty months have zero values."""
@@ -477,7 +476,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Coffee",
             bank_category=None,
-            amount=Decimal("5.00"),
+            amount=500,
             transaction_type="expense",
         )
         t.data_import_id = data_import.id
@@ -492,19 +491,19 @@ class TestGetPeriodSummary:
 
         # January has data
         jan_summary = result["cash_basis"]["2024/01"]
-        assert jan_summary["expense_total"] == Decimal("5.00")
+        assert jan_summary["expense_total"] == 500
 
         # February and March are empty
         feb_summary = result["cash_basis"]["2024/02"]
-        assert feb_summary["income_total"] == Decimal("0")
-        assert feb_summary["expense_total"] == Decimal("0")
-        assert feb_summary["net"] == Decimal("0")
+        assert feb_summary["income_total"] == 0
+        assert feb_summary["expense_total"] == 0
+        assert feb_summary["net"] == 0
         assert len(feb_summary["expenses_by_category"]) == 0
 
         mar_summary = result["cash_basis"]["2024/03"]
-        assert mar_summary["income_total"] == Decimal("0")
-        assert mar_summary["expense_total"] == Decimal("0")
-        assert mar_summary["net"] == Decimal("0")
+        assert mar_summary["income_total"] == 0
+        assert mar_summary["expense_total"] == 0
+        assert mar_summary["net"] == 0
         assert len(mar_summary["expenses_by_category"]) == 0
 
     def test_category_filter(self, services):
@@ -522,7 +521,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Food",
             bank_category=None,
-            amount=Decimal("100.00"),
+            amount=10000,
             transaction_type="expense",
         )
         t1.data_import_id = data_import.id
@@ -536,7 +535,7 @@ class TestGetPeriodSummary:
             post_date=None,
             description="Gas",
             bank_category=None,
-            amount=Decimal("50.00"),
+            amount=5000,
             transaction_type="expense",
         )
         t2.data_import_id = data_import.id
@@ -553,8 +552,8 @@ class TestGetPeriodSummary:
 
         summary = result["cash_basis"]["2024/01"]
         # Should only include food expense
-        assert summary["expense_total"] == Decimal("100.00")
-        assert summary["expenses_by_category"][category1.id] == Decimal("100.00")
+        assert summary["expense_total"] == 10000
+        assert summary["expenses_by_category"][category1.id] == 10000
         assert category2.id not in summary["expenses_by_category"]
 
     def test_multi_month_summary(self, services):
@@ -572,7 +571,7 @@ class TestGetPeriodSummary:
                 post_date=None,
                 description=f"Food {month}",
                 bank_category=None,
-                amount=Decimal(f"{month * 100}.00"),
+                amount=month * 10000,
                 transaction_type="expense",
             )
             t.data_import_id = data_import.id
@@ -586,6 +585,6 @@ class TestGetPeriodSummary:
         )
 
         # Check each month
-        assert result["cash_basis"]["2024/01"]["expense_total"] == Decimal("100.00")
-        assert result["cash_basis"]["2024/02"]["expense_total"] == Decimal("200.00")
-        assert result["cash_basis"]["2024/03"]["expense_total"] == Decimal("300.00")
+        assert result["cash_basis"]["2024/01"]["expense_total"] == 10000
+        assert result["cash_basis"]["2024/02"]["expense_total"] == 20000
+        assert result["cash_basis"]["2024/03"]["expense_total"] == 30000

--- a/tools/transactions.py
+++ b/tools/transactions.py
@@ -1,7 +1,6 @@
 """Transaction analysis tools."""
 
 from datetime import date
-from decimal import Decimal
 from typing import Dict, List, Optional
 from models.transaction import Transaction
 
@@ -104,20 +103,20 @@ def get_period_summary(
         month keys (format: "YYYY/MM") mapped to summary dictionaries:
         - "income_total": Total income for the month (Decimal)
         - "expense_total": Total expenses for the month (Decimal)
-        - "net": Net amount (income - expenses) (Decimal)
-        - "expenses_by_category": Dict mapping category_id to expense amount (Decimal)
+        - "net": Net amount (income - expenses) in cents (int)
+        - "expenses_by_category": Dict mapping category_id to expense amount in cents (int)
           (category_id=0 for uncategorized transactions)
 
     Example:
         {
             "cash_basis": {
                 "2024/01": {
-                    "income_total": Decimal("1000.00"),
-                    "expense_total": Decimal("500.00"),
-                    "net": Decimal("500.00"),
+                    "income_total": 100000,
+                    "expense_total": 50000,
+                    "net": 50000,
                     "expenses_by_category": {
-                        1: Decimal("200.00"),  # Food category
-                        2: Decimal("300.00"),  # Transportation category
+                        1: 20000,  # Food category
+                        2: 30000,  # Transportation category
                     }
                 },
                 "2024/02": {...},
@@ -142,9 +141,9 @@ def get_period_summary(
     for basis_type in ["cash_basis", "accrual_basis"]:
         # Process each month
         for month_key, transactions in transactions_data[basis_type].items():
-            income_total = Decimal("0")
-            expense_total = Decimal("0")
-            expenses_by_category: Dict[int, Decimal] = {}
+            income_total = 0
+            expense_total = 0
+            expenses_by_category: Dict[int, int] = {}
 
             # Aggregate transactions
             for transaction in transactions:
@@ -161,7 +160,7 @@ def get_period_summary(
                     )
 
                     if category_id not in expenses_by_category:
-                        expenses_by_category[category_id] = Decimal("0")
+                        expenses_by_category[category_id] = 0
                     expenses_by_category[category_id] += transaction.amount
 
             # Calculate net


### PR DESCRIPTION
## Summary
- Add migration `010_amount_to_integer.sql` to convert `amount REAL` → `amount INTEGER` (cents) in the transactions table
- Change `Transaction.amount` from `Decimal` to `int` throughout the stack
- Ingestion modules multiply parsed Decimal amounts by 100 to produce integer cents
- Service layer stores/reads ints directly; no more `float()` conversion on insert
- Accrued amount calculation uses `round(amount / months)` for integer cents
- CLI display divides by 100 for human-readable dollar formatting
- Tools aggregation uses plain `int` arithmetic instead of `Decimal`

## References
Fixes #18

## Test plan
- All 237 existing tests pass with no changes to test logic, only amount literals updated from `Decimal("X.YZ")` to integer cents
- Run: `uv run pytest tests/ -x -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)