### PR TITLE
Create repositories package from DB-access service classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,10 @@ uv sync --group dev
 - `db/` contains code for database connection management, and
   migrations
 - `llm/` contains code and prompts to communicate with LLMs
-- `services/` contains code for relatively simple queries on the
-  database
+- `repositories/` contains repository classes — pure DB operations
+  (SQL queries and row-to-object mapping) for each model
+- `services/` contains the `Services` dependency-injection container
+  that exposes repositories to the rest of the app
 - `tools/` contains higher level tools that make use of the services
 
 ## Pre-commit Checks

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 
 ## Phase 1: Restructure existing code into repositories/services/cli layers
 
-### 1. Create `repositories/` package from current DB-access classes
+### 1. Create `repositories/` package from current DB-access classes ✅
 
 Move the four DB-access classes from `services/` into a new `repositories/` package.
 These classes contain only SQL queries and row-to-object mapping — no business logic.

--- a/repositories/accounts.py
+++ b/repositories/accounts.py
@@ -1,14 +1,14 @@
-"""Account service for database operations."""
+"""Account repository for database operations."""
 
 from typing import List, Optional
 from models.account import Account
 
 
-class AccountService:
-    """Service for managing accounts."""
+class AccountRepository:
+    """Repository for managing accounts."""
 
     def __init__(self, db_manager):
-        """Initialize the account service.
+        """Initialize the account repository.
 
         Args:
             db_manager: Database manager instance for database operations.

--- a/repositories/categories.py
+++ b/repositories/categories.py
@@ -1,14 +1,14 @@
-"""Category service for database operations."""
+"""Category repository for database operations."""
 
 from typing import List, Optional
 from models.category import Category
 
 
-class CategoryService:
-    """Service for managing categories."""
+class CategoryRepository:
+    """Repository for managing categories."""
 
     def __init__(self, db_manager):
-        """Initialize the category service.
+        """Initialize the category repository.
 
         Args:
             db_manager: Database manager instance for database operations.

--- a/repositories/data_imports.py
+++ b/repositories/data_imports.py
@@ -1,15 +1,15 @@
-"""DataImport service for database operations."""
+"""DataImport repository for database operations."""
 
 from typing import List, Optional
 from datetime import datetime
 from models.data_import import DataImport
 
 
-class DataImportService:
-    """Service for managing data import records."""
+class DataImportRepository:
+    """Repository for managing data import records."""
 
     def __init__(self, db_manager):
-        """Initialize the data import service.
+        """Initialize the data import repository.
 
         Args:
             db_manager: Database manager instance for database operations.

--- a/repositories/transactions.py
+++ b/repositories/transactions.py
@@ -1,4 +1,4 @@
-"""Transaction service for database operations."""
+"""Transaction repository for database operations."""
 
 import json
 import logging
@@ -23,11 +23,11 @@ _TRANSACTION_INSERT_PLACEHOLDERS = (
 )
 
 
-class TransactionService:
-    """Service for managing transactions."""
+class TransactionRepository:
+    """Repository for managing transactions."""
 
     def __init__(self, db_manager):
-        """Initialize the transaction service.
+        """Initialize the transaction repository.
 
         Args:
             db_manager: Database manager instance for database operations.

--- a/services/base.py
+++ b/services/base.py
@@ -27,12 +27,12 @@ class Services:
         self.db_manager = db_manager or DatabaseManager(config)
 
         # Lazy import to avoid circular dependencies
-        from services.accounts import AccountService
-        from services.transactions import TransactionService
-        from services.data_imports import DataImportService
-        from services.categories import CategoryService
+        from repositories.accounts import AccountRepository
+        from repositories.transactions import TransactionRepository
+        from repositories.data_imports import DataImportRepository
+        from repositories.categories import CategoryRepository
 
-        self.accounts = AccountService(self.db_manager)
-        self.transactions = TransactionService(self.db_manager)
-        self.data_imports = DataImportService(self.db_manager)
-        self.categories = CategoryService(self.db_manager)
+        self.accounts = AccountRepository(self.db_manager)
+        self.transactions = TransactionRepository(self.db_manager)
+        self.data_imports = DataImportRepository(self.db_manager)
+        self.categories = CategoryRepository(self.db_manager)


### PR DESCRIPTION
## Summary
Phase 1, Part 1 of the architecture v2 refactor (TODO.md):

- New `repositories/` package contains the four pure DB-access classes
  (`AccountRepository`, `TransactionRepository`, `CategoryRepository`,
  `DataImportRepository`), moved from `services/` and renamed from
  `*Service` → `*Repository`.
- `services/base.py` wires the new repositories into the existing
  `Services` container. The container's public attribute names
  (`accounts`, `transactions`, `categories`, `data_imports`) are
  unchanged, so no downstream code needed updates.
- CLAUDE.md project structure section updated to mention `repositories/`.
- TODO.md item 1 marked done.

No test files needed updating: they all access these classes through
the `services` fixture, never via direct import.

## References
TODO.md → Phase 1 → "1. Create `repositories/` package from current
DB-access classes"

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pytest` — 237 tests pass
- [x] `uv run python -m cli --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)