### PR TITLE
Move business logic into services/ package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,8 @@ uv sync --group dev
 - `repositories/` contains repository classes — pure DB operations
   (SQL queries and row-to-object mapping) for each model
 - `services/` contains the `Services` dependency-injection container
-  that exposes repositories to the rest of the app
-- `tools/` contains higher level tools that make use of the services
+  that exposes repositories, plus business logic modules (`analysis.py`,
+  `categorization.py`)
 
 ## Pre-commit Checks
 

--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@ Update all test files that directly import these classes (check `tests/services/
 
 Run `uv run ruff check .` and `uv run pytest` to verify nothing is broken.
 
-### 2. Move business logic into `services/` package
+### 2. Move business logic into `services/` package ✅
 
 Now that the DB-access classes have moved out of `services/`, repurpose `services/`
 as the business logic layer.

--- a/cli/transactions.py
+++ b/cli/transactions.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 from datetime import datetime
 from ingestion import get_ingestion_module
-from categorization import auto_categorize
+from services.categorization import auto_categorize
 from logger import get_logger
 
 logger = get_logger()

--- a/services/analysis.py
+++ b/services/analysis.py
@@ -1,4 +1,4 @@
-"""Transaction analysis tools."""
+"""Transaction analysis service."""
 
 from datetime import date
 from typing import Dict, List, Optional

--- a/services/categorization.py
+++ b/services/categorization.py
@@ -1,4 +1,4 @@
-"""Auto-categorization module using LLM for transaction categorization.
+"""Auto-categorization service using LLM for transaction categorization.
 
 This module provides functionality to automatically categorize transactions
 using a Large Language Model (LLM). The LLM learns from historical manually-

--- a/tests/services/test_analysis.py
+++ b/tests/services/test_analysis.py
@@ -1,10 +1,10 @@
-"""Tests for transaction analysis tools."""
+"""Tests for transaction analysis service."""
 
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
 from models.transaction import Transaction
-from tools.transactions import get_period_transactions, get_period_summary
+from services.analysis import get_period_transactions, get_period_summary
 
 
 class TestGetPeriodTransactions:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,0 @@
-"""Tools for working with transaction data and financial analysis."""


### PR DESCRIPTION
## Summary
- Moved `get_period_transactions` and `get_period_summary` from `tools/transactions.py` → `services/analysis.py`
- Moved `auto_categorize` from top-level `categorization.py` → `services/categorization.py`
- Deleted `tools/transactions.py`, `tools/__init__.py`, `categorization.py`
- Updated `cli/transactions.py` to import from `services.categorization`
- Moved `tests/tools/test_transactions.py` → `tests/services/test_analysis.py` with updated imports
- Updated CLAUDE.md project structure

## References
TODO.md Phase 1, Step 2: Move business logic into `services/` package

## Test plan
- `uv run pytest` — 237 tests pass
- `uv run ruff check .` — no errors
- `uv run python -m cli --help` — all subcommands accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)