### PR TITLE
Phase 1 cleanup: remove empty packages, update architecture docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,10 @@ If `ruff check` reports errors, fix them before committing. Do not skip this ste
 
 ## Architecture Notes
 
-The project is currently in early stages with a minimal main.py file. The presence of sample bank CSV files suggests this will be a financial data processing tool, likely for:
-- Parsing different bank transaction formats
-- Standardizing transaction data
-- Categorizing transactions
-- Financial analysis or reporting
+The project follows a layered architecture:
 
-The CSV samples show different bank formats with common fields like Date, Description, Amount, and Category, indicating the tool will need to handle format variations across different financial institutions.
+- **repositories layer** (`repositories/`): pure DB operations — SQL queries and row-to-object mapping, no business logic
+- **services layer** (`services/`): business logic — ingestion orchestration, analysis, auto-categorization; also hosts the `Services` DI container
+- **interface layer** (`cli/`): input validation and output only — delegates all logic to services
+
+The `Services` class in `services/base.py` is the central dependency-injection container. It wires together the database manager and all repositories, and is passed through to service functions and CLI commands.

--- a/TODO.md
+++ b/TODO.md
@@ -86,7 +86,7 @@ to a service, but this is lower priority. If it's straightforward, extract it to
 
 Run `uv run ruff check .` and `uv run pytest` to verify.
 
-### 4. Clean up and verify the restructure
+### 4. Clean up and verify the restructure ✅
 
 Final verification pass:
 - Ensure no imports reference deleted modules (`tools.*`, top-level `categorization`)

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for tools package."""


### PR DESCRIPTION
## Summary
- Removed empty `tests/tools/` package (the test file moved to `tests/services/` in Part 2)
- Removed empty `tools/` directory (the module moved to `services/` in Part 2)
- Rewrote stale "Architecture Notes" section in CLAUDE.md to describe the actual layered architecture (repositories → services → CLI)

## References
TODO.md Phase 1, Step 4: Clean up and verify the restructure

## Test plan
- `uv run ruff check .` — no errors
- `uv run pytest` — 252 tests pass
- `uv run python -m cli --help` — all subcommands accessible
- No references to `tools.*` or top-level `categorization` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)