### PR TITLE
Add API blueprint with core resource routes (Phase 2, item 6)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -129,7 +129,14 @@ e.g., `uv run python -m cli serve`.
 
 Verify the server starts and serves the base template at `http://localhost:5000/`.
 
-### 6. Add API blueprint with core resource routes
+### 6. Add API blueprint with core resource routes ✅
+
+Implementation plan:
+- Fill in `app/api/routes.py` with 6 read-only routes using `current_app.services`
+- Serialize models inline (Account.to_dict(), Category/Transaction via helper)
+- Error format: `{"error": "not_found"|"bad_request", "message": "..."}` with 400/404
+- `GET /api/transactions/summary` registered before `<id>` to avoid route conflict
+- Tests: Flask test client, fixtures create accounts/categories/transactions in DB
 
 Create `app/api/__init__.py` and `app/api/routes.py`.
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,3 +1,180 @@
-"""API route definitions (placeholder — populated in Phase 2 item 6)."""
+"""API route definitions — read-only JSON endpoints."""
 
-from app.api import api_bp  # noqa: F401
+from datetime import date
+
+from flask import jsonify, request, current_app
+
+from app.api import api_bp
+from services import analysis
+
+
+def _transaction_to_dict(t) -> dict:
+    return {
+        "id": t.id,
+        "account_id": t.account_id,
+        "data_import_id": t.data_import_id,
+        "transaction_date": t.transaction_date.isoformat(),
+        "post_date": t.post_date.isoformat() if t.post_date else None,
+        "description": t.description,
+        "bank_category": t.bank_category,
+        "category_id": t.category_id,
+        "auto_category_id": t.auto_category_id,
+        "merchant_name": t.merchant_name,
+        "auto_merchant_name": t.auto_merchant_name,
+        "amount": t.amount,
+        "transaction_type": t.transaction_type,
+        "amortize_months": t.amortize_months,
+        "amortize_end_date": (
+            t.amortize_end_date.isoformat() if t.amortize_end_date else None
+        ),
+        "accrued": t.accrued,
+    }
+
+
+def _category_to_dict(c) -> dict:
+    return {
+        "id": c.id,
+        "name": c.name,
+        "description": c.description,
+        "parent_id": c.parent_id,
+    }
+
+
+def _parse_month(value: str, param_name: str):
+    """Parse a YYYY/MM string into (year, month). Returns (None, error_response) on failure."""
+    try:
+        year_str, month_str = value.split("/")
+        year = int(year_str)
+        month = int(month_str)
+        if not (1 <= month <= 12):
+            raise ValueError
+        return (year, month), None
+    except (ValueError, AttributeError):
+        return None, (
+            jsonify(
+                {
+                    "error": "bad_request",
+                    "message": f"'{param_name}' must be in YYYY/MM format",
+                }
+            ),
+            400,
+        )
+
+
+# --- Accounts ---
+
+
+@api_bp.route("/accounts")
+def list_accounts():
+    accounts = current_app.services.accounts.find_all()
+    return jsonify([a.to_dict() for a in accounts])
+
+
+@api_bp.route("/accounts/<int:account_id>")
+def get_account(account_id):
+    account = current_app.services.accounts.find(account_id)
+    if account is None:
+        return jsonify(
+            {"error": "not_found", "message": f"Account {account_id} not found"}
+        ), 404
+    return jsonify(account.to_dict())
+
+
+# --- Categories ---
+
+
+@api_bp.route("/categories")
+def list_categories():
+    categories = current_app.services.categories.find_all()
+    return jsonify([_category_to_dict(c) for c in categories])
+
+
+# --- Transactions ---
+
+
+@api_bp.route("/transactions/summary")
+def get_transactions_summary():
+    start_raw = request.args.get("start")
+    end_raw = request.args.get("end")
+
+    if not start_raw:
+        return jsonify(
+            {"error": "bad_request", "message": "'start' query parameter is required"}
+        ), 400
+    if not end_raw:
+        return jsonify(
+            {"error": "bad_request", "message": "'end' query parameter is required"}
+        ), 400
+
+    start_parsed, err = _parse_month(start_raw, "start")
+    if err:
+        return err
+    start_year, start_month = start_parsed
+
+    end_parsed, err = _parse_month(end_raw, "end")
+    if err:
+        return err
+    end_year, end_month = end_parsed
+
+    start_date = date(start_year, start_month, 1)
+    end_date = date(end_year, end_month, 1)
+
+    if end_date < start_date:
+        return jsonify(
+            {"error": "bad_request", "message": "'end' must not be before 'start'"}
+        ), 400
+
+    summary = analysis.get_period_summary(current_app.services, start_date, end_date)
+
+    # Serialize: expenses_by_category keys are ints; convert to str for JSON compatibility
+    def _serialize_basis(basis_data):
+        result = {}
+        for month_key, month_summary in basis_data.items():
+            result[month_key] = {
+                "income_total": month_summary["income_total"],
+                "expense_total": month_summary["expense_total"],
+                "net": month_summary["net"],
+                "expenses_by_category": {
+                    str(k): v for k, v in month_summary["expenses_by_category"].items()
+                },
+            }
+        return result
+
+    return jsonify(
+        {
+            "cash_basis": _serialize_basis(summary["cash_basis"]),
+            "accrual_basis": _serialize_basis(summary["accrual_basis"]),
+        }
+    )
+
+
+@api_bp.route("/transactions")
+def list_transactions():
+    month_raw = request.args.get("month")
+    if not month_raw:
+        return jsonify(
+            {"error": "bad_request", "message": "'month' query parameter is required"}
+        ), 400
+
+    month_parsed, err = _parse_month(month_raw, "month")
+    if err:
+        return err
+    year, month = month_parsed
+
+    transactions = current_app.services.transactions.get_transactions_by_month(
+        year, month
+    )
+    return jsonify([_transaction_to_dict(t) for t in transactions])
+
+
+@api_bp.route("/transactions/<transaction_id>")
+def get_transaction(transaction_id):
+    transaction = current_app.services.transactions.find(transaction_id)
+    if transaction is None:
+        return jsonify(
+            {
+                "error": "not_found",
+                "message": f"Transaction {transaction_id!r} not found",
+            }
+        ), 404
+    return jsonify(_transaction_to_dict(transaction))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,185 @@
+"""Tests for the API blueprint routes."""
+
+import pytest
+from datetime import date
+
+from app.app import create_app
+from services.base import Services
+from models.transaction import Transaction
+
+
+@pytest.fixture
+def app(test_config, db_manager_with_schema):
+    svc = Services(test_config, db_manager=db_manager_with_schema)
+    flask_app = create_app(config=test_config, services=svc)
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def svc(app):
+    return app.services
+
+
+@pytest.fixture
+def account(svc):
+    return svc.accounts.create("bofa_checking", "bofa", "Bank of America Checking")
+
+
+@pytest.fixture
+def category(svc):
+    return svc.categories.create("Food", "Food expenses")
+
+
+@pytest.fixture
+def data_import(svc, account):
+    return svc.data_imports.create(account_id=account.id, filename=None)
+
+
+@pytest.fixture
+def transaction(svc, account, data_import):
+    t = Transaction.create_with_checksum(
+        raw_data="row1",
+        account_id=account.id,
+        transaction_date=date(2025, 3, 15),
+        post_date=None,
+        description="Grocery Store",
+        bank_category="Groceries",
+        amount=4200,
+        transaction_type="expense",
+    )
+    t.data_import_id = data_import.id
+    return svc.transactions.create(t)
+
+
+# --- Accounts ---
+
+
+class TestAccountsAPI:
+    def test_list_accounts_empty(self, client):
+        resp = client.get("/api/accounts")
+        assert resp.status_code == 200
+        assert resp.json == []
+
+    def test_list_accounts_returns_accounts(self, client, account):
+        resp = client.get("/api/accounts")
+        assert resp.status_code == 200
+        data = resp.json
+        assert len(data) == 1
+        assert data[0]["name"] == "bofa_checking"
+        assert data[0]["id"] == account.id
+
+    def test_get_account_found(self, client, account):
+        resp = client.get(f"/api/accounts/{account.id}")
+        assert resp.status_code == 200
+        assert resp.json["name"] == "bofa_checking"
+
+    def test_get_account_not_found(self, client):
+        resp = client.get("/api/accounts/9999")
+        assert resp.status_code == 404
+        assert resp.json["error"] == "not_found"
+
+
+# --- Categories ---
+
+
+class TestCategoriesAPI:
+    def test_list_categories_empty(self, client):
+        resp = client.get("/api/categories")
+        assert resp.status_code == 200
+        assert resp.json == []
+
+    def test_list_categories_returns_categories(self, client, category):
+        resp = client.get("/api/categories")
+        assert resp.status_code == 200
+        data = resp.json
+        assert len(data) == 1
+        assert data[0]["name"] == "Food"
+
+
+# --- Transactions ---
+
+
+class TestTransactionsAPI:
+    def test_list_transactions_missing_month(self, client):
+        resp = client.get("/api/transactions")
+        assert resp.status_code == 400
+        assert resp.json["error"] == "bad_request"
+
+    def test_list_transactions_bad_month_format(self, client):
+        resp = client.get("/api/transactions?month=2025-03")
+        assert resp.status_code == 400
+        assert resp.json["error"] == "bad_request"
+
+    def test_list_transactions_empty_month(self, client, account):
+        resp = client.get("/api/transactions?month=2025/01")
+        assert resp.status_code == 200
+        assert resp.json == []
+
+    def test_list_transactions_returns_transactions(self, client, transaction):
+        resp = client.get("/api/transactions?month=2025/03")
+        assert resp.status_code == 200
+        data = resp.json
+        assert len(data) == 1
+        assert data[0]["description"] == "Grocery Store"
+        assert data[0]["amount"] == 4200
+        assert data[0]["transaction_date"] == "2025-03-15"
+
+    def test_get_transaction_found(self, client, transaction):
+        resp = client.get(f"/api/transactions/{transaction.id}")
+        assert resp.status_code == 200
+        assert resp.json["description"] == "Grocery Store"
+
+    def test_get_transaction_not_found(self, client):
+        resp = client.get("/api/transactions/nonexistent-id")
+        assert resp.status_code == 404
+        assert resp.json["error"] == "not_found"
+
+
+# --- Summary ---
+
+
+class TestSummaryAPI:
+    def test_summary_missing_start(self, client):
+        resp = client.get("/api/transactions/summary?end=2025/03")
+        assert resp.status_code == 400
+        assert resp.json["error"] == "bad_request"
+
+    def test_summary_missing_end(self, client):
+        resp = client.get("/api/transactions/summary?start=2025/01")
+        assert resp.status_code == 400
+        assert resp.json["error"] == "bad_request"
+
+    def test_summary_bad_format(self, client):
+        resp = client.get("/api/transactions/summary?start=2025-01&end=2025-03")
+        assert resp.status_code == 400
+        assert resp.json["error"] == "bad_request"
+
+    def test_summary_end_before_start(self, client):
+        resp = client.get("/api/transactions/summary?start=2025/03&end=2025/01")
+        assert resp.status_code == 400
+        assert resp.json["error"] == "bad_request"
+
+    def test_summary_empty_period(self, client, account):
+        resp = client.get("/api/transactions/summary?start=2025/01&end=2025/01")
+        assert resp.status_code == 200
+        data = resp.json
+        assert "cash_basis" in data
+        assert "accrual_basis" in data
+        assert "2025/01" in data["cash_basis"]
+        assert data["cash_basis"]["2025/01"]["income_total"] == 0
+        assert data["cash_basis"]["2025/01"]["expense_total"] == 0
+
+    def test_summary_with_transactions(self, client, transaction):
+        resp = client.get("/api/transactions/summary?start=2025/03&end=2025/03")
+        assert resp.status_code == 200
+        data = resp.json
+        month = data["cash_basis"]["2025/03"]
+        assert month["expense_total"] == 4200
+        assert month["income_total"] == 0
+        assert month["net"] == -4200


### PR DESCRIPTION
## Summary
- Implements 6 read-only JSON routes in `app/api/routes.py`:
  - `GET /api/accounts` — list all accounts
  - `GET /api/accounts/<id>` — single account (404 if not found)
  - `GET /api/categories` — list all categories
  - `GET /api/transactions?month=YYYY/MM` — transactions for a month (400 if missing/malformed)
  - `GET /api/transactions/<id>` — single transaction (404 if not found)
  - `GET /api/transactions/summary?start=YYYY/MM&end=YYYY/MM` — period summary with cash/accrual breakdown
- Error format follows architecture doc: `{"error": "not_found"|"bad_request", "message": "..."}` with 400/404
- `GET /api/transactions/summary` is registered before `<transaction_id>` to avoid route conflicts

## References
TODO.md Phase 2, item 6

## Test plan
- 18 new tests in `tests/test_api.py` using Flask test client
- Covers: list (empty and populated), single-resource fetch, 404 not found, missing/invalid query params, bad date ranges
- Full suite: 326 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)