### PR TITLE
Add UI blueprint with htmx fragment routes (Phase 2, item 7)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -156,7 +156,13 @@ from the architecture doc.
 
 Add basic tests for the API routes using Flask's test client.
 
-### 7. Add UI blueprint with htmx transaction views
+### 7. Add UI blueprint with htmx transaction views ✅
+
+Implementation plan:
+- Fill in `app/ui/routes.py` with 3 routes; `/ui/transactions` defaults to current month if no `?month=` given
+- Fragment templates: transaction_list (table + prev/next month nav), account_list (table), category_list (table)
+- `base.html` nav already has correct htmx links from item 5 — no change needed
+- Tests: Flask test client checking status codes and key HTML strings
 
 Create `app/ui/__init__.py` and `app/ui/routes.py`.
 

--- a/app/templates/fragments/account_list.html
+++ b/app/templates/fragments/account_list.html
@@ -1,0 +1,25 @@
+<section>
+  <h2>Accounts</h2>
+  {% if accounts %}
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for account in accounts %}
+      <tr>
+        <td>{{ account.name }}</td>
+        <td>{{ account.account_type }}</td>
+        <td>{{ account.description }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>No accounts found.</p>
+  {% endif %}
+</section>

--- a/app/templates/fragments/category_list.html
+++ b/app/templates/fragments/category_list.html
@@ -1,0 +1,23 @@
+<section>
+  <h2>Categories</h2>
+  {% if categories %}
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for category in categories %}
+      <tr>
+        <td>{{ category.name }}</td>
+        <td>{{ category.description or '' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>No categories found.</p>
+  {% endif %}
+</section>

--- a/app/templates/fragments/transaction_list.html
+++ b/app/templates/fragments/transaction_list.html
@@ -1,0 +1,46 @@
+{% if error %}
+<p><strong>Error:</strong> {{ error }}</p>
+{% else %}
+<section>
+  <nav>
+    <a hx-get="/ui/transactions?month={{ prev_month }}" hx-target="#content">&larr; {{ prev_month }}</a>
+    <strong>{{ month_label }}</strong>
+    <a hx-get="/ui/transactions?month={{ next_month }}" hx-target="#content">{{ next_month }} &rarr;</a>
+  </nav>
+
+  {% if transactions %}
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Description</th>
+        <th>Merchant</th>
+        <th>Category</th>
+        <th>Amount</th>
+        <th>Type</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for t in transactions %}
+      <tr>
+        <td>{{ t.transaction_date.isoformat() }}</td>
+        <td>{{ t.description }}</td>
+        <td>{{ t.merchant_name or t.auto_merchant_name or '' }}</td>
+        <td>
+          {% if t.category_id and t.category_id in categories %}
+            {{ categories[t.category_id] }}
+          {% elif t.auto_category_id and t.auto_category_id in categories %}
+            <em>{{ categories[t.auto_category_id] }}</em>
+          {% endif %}
+        </td>
+        <td>${{ "%.2f"|format(t.amount / 100) }}</td>
+        <td>{{ t.transaction_type }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>No transactions for {{ month_label }}.</p>
+  {% endif %}
+</section>
+{% endif %}

--- a/app/ui/routes.py
+++ b/app/ui/routes.py
@@ -1,3 +1,85 @@
-"""UI route definitions (placeholder — populated in Phase 2 item 7)."""
+"""UI route definitions — server-rendered HTML fragments for htmx."""
 
-from app.ui import ui_bp  # noqa: F401
+from datetime import date
+
+from flask import render_template, request, current_app
+
+from app.ui import ui_bp
+
+
+def _parse_month(value: str):
+    """Parse a YYYY/MM string. Returns (year, month) or raises ValueError."""
+    year_str, month_str = value.split("/")
+    year = int(year_str)
+    month = int(month_str)
+    if not (1 <= month <= 12):
+        raise ValueError(f"month {month} out of range")
+    return year, month
+
+
+def _adjacent_months(year: int, month: int):
+    """Return (prev_year, prev_month, next_year, next_month) for navigation."""
+    if month == 1:
+        prev_year, prev_month = year - 1, 12
+    else:
+        prev_year, prev_month = year, month - 1
+
+    if month == 12:
+        next_year, next_month = year + 1, 1
+    else:
+        next_year, next_month = year, month + 1
+
+    return prev_year, prev_month, next_year, next_month
+
+
+@ui_bp.route("/transactions")
+def transactions():
+    month_raw = request.args.get("month")
+
+    if month_raw:
+        try:
+            year, month = _parse_month(month_raw)
+        except (ValueError, AttributeError):
+            return render_template(
+                "fragments/transaction_list.html",
+                error=f"Invalid month format '{month_raw}'. Use YYYY/MM.",
+                transactions=[],
+                categories={},
+                month_label=None,
+                prev_month=None,
+                next_month=None,
+            ), 400
+    else:
+        today = date.today()
+        year, month = today.year, today.month
+
+    txns = current_app.services.transactions.get_transactions_by_month(year, month)
+
+    # Build category lookup for display
+    all_categories = current_app.services.categories.find_all()
+    categories = {c.id: c.name for c in all_categories}
+
+    month_label = f"{year:04d}/{month:02d}"
+    prev_year, prev_month, next_year, next_month = _adjacent_months(year, month)
+
+    return render_template(
+        "fragments/transaction_list.html",
+        error=None,
+        transactions=txns,
+        categories=categories,
+        month_label=month_label,
+        prev_month=f"{prev_year:04d}/{prev_month:02d}",
+        next_month=f"{next_year:04d}/{next_month:02d}",
+    )
+
+
+@ui_bp.route("/accounts")
+def accounts():
+    all_accounts = current_app.services.accounts.find_all()
+    return render_template("fragments/account_list.html", accounts=all_accounts)
+
+
+@ui_bp.route("/categories")
+def categories():
+    all_categories = current_app.services.categories.find_all()
+    return render_template("fragments/category_list.html", categories=all_categories)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,153 @@
+"""Tests for the UI blueprint routes."""
+
+from datetime import date
+
+import pytest
+
+from app.app import create_app
+from models.transaction import Transaction
+from services.base import Services
+
+
+@pytest.fixture
+def app(test_config, db_manager_with_schema):
+    svc = Services(test_config, db_manager=db_manager_with_schema)
+    flask_app = create_app(config=test_config, services=svc)
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def svc(app):
+    return app.services
+
+
+@pytest.fixture
+def account(svc):
+    return svc.accounts.create("bofa_checking", "bofa", "Bank of America Checking")
+
+
+@pytest.fixture
+def category(svc):
+    return svc.categories.create("Food", "Food expenses")
+
+
+@pytest.fixture
+def data_import(svc, account):
+    return svc.data_imports.create(account_id=account.id, filename=None)
+
+
+@pytest.fixture
+def transaction(svc, account, data_import):
+    t = Transaction.create_with_checksum(
+        raw_data="ui-row1",
+        account_id=account.id,
+        transaction_date=date(2025, 3, 15),
+        post_date=None,
+        description="Grocery Store",
+        bank_category="Groceries",
+        amount=4200,
+        transaction_type="expense",
+    )
+    t.data_import_id = data_import.id
+    return svc.transactions.create(t)
+
+
+# --- /ui/accounts ---
+
+
+class TestAccountsUI:
+    def test_accounts_returns_200(self, client):
+        resp = client.get("/ui/accounts")
+        assert resp.status_code == 200
+
+    def test_accounts_empty(self, client):
+        html = client.get("/ui/accounts").data.decode()
+        assert "No accounts found" in html
+
+    def test_accounts_lists_accounts(self, client, account):
+        html = client.get("/ui/accounts").data.decode()
+        assert "bofa_checking" in html
+        assert "Bank of America Checking" in html
+
+    def test_accounts_renders_table(self, client, account):
+        html = client.get("/ui/accounts").data.decode()
+        assert "<table>" in html
+        assert "<th>" in html
+
+
+# --- /ui/categories ---
+
+
+class TestCategoriesUI:
+    def test_categories_returns_200(self, client):
+        resp = client.get("/ui/categories")
+        assert resp.status_code == 200
+
+    def test_categories_empty(self, client):
+        html = client.get("/ui/categories").data.decode()
+        assert "No categories found" in html
+
+    def test_categories_lists_categories(self, client, category):
+        html = client.get("/ui/categories").data.decode()
+        assert "Food" in html
+        assert "Food expenses" in html
+
+
+# --- /ui/transactions ---
+
+
+class TestTransactionsUI:
+    def test_transactions_returns_200_with_month(self, client):
+        resp = client.get("/ui/transactions?month=2025/03")
+        assert resp.status_code == 200
+
+    def test_transactions_defaults_to_current_month(self, client):
+        # No month param — should not error
+        resp = client.get("/ui/transactions")
+        assert resp.status_code == 200
+
+    def test_transactions_invalid_month_returns_400(self, client):
+        resp = client.get("/ui/transactions?month=2025-03")
+        assert resp.status_code == 400
+
+    def test_transactions_invalid_month_shows_error(self, client):
+        html = client.get("/ui/transactions?month=badmonth").data.decode()
+        assert "Error" in html
+
+    def test_transactions_empty_month(self, client):
+        html = client.get("/ui/transactions?month=2025/01").data.decode()
+        assert "No transactions" in html
+
+    def test_transactions_shows_month_label(self, client):
+        html = client.get("/ui/transactions?month=2025/03").data.decode()
+        assert "2025/03" in html
+
+    def test_transactions_shows_prev_next_navigation(self, client):
+        html = client.get("/ui/transactions?month=2025/03").data.decode()
+        assert "2025/02" in html  # prev month
+        assert "2025/04" in html  # next month
+
+    def test_transactions_lists_transactions(self, client, transaction):
+        html = client.get("/ui/transactions?month=2025/03").data.decode()
+        assert "Grocery Store" in html
+        assert "42.00" in html  # $42.00
+
+    def test_transactions_renders_table(self, client, transaction):
+        html = client.get("/ui/transactions?month=2025/03").data.decode()
+        assert "<table>" in html
+
+    def test_transactions_year_boundary_prev(self, client):
+        # January → prev should be December of previous year
+        html = client.get("/ui/transactions?month=2025/01").data.decode()
+        assert "2024/12" in html
+
+    def test_transactions_year_boundary_next(self, client):
+        # December → next should be January of next year
+        html = client.get("/ui/transactions?month=2025/12").data.decode()
+        assert "2026/01" in html


### PR DESCRIPTION
## Summary
- Implements 3 routes in `app/ui/routes.py`:
  - `GET /ui/transactions?month=YYYY/MM` — renders transaction list fragment; defaults to current month if `month` omitted; returns 400 with inline error on bad format
  - `GET /ui/accounts` — renders account list fragment
  - `GET /ui/categories` — renders category list fragment
- Creates fragment templates in `app/templates/fragments/`:
  - `transaction_list.html` — table with date/description/merchant/category/amount columns and prev/next month navigation via htmx
  - `account_list.html` — accounts table
  - `category_list.html` — categories table
- `base.html` nav already had correct `hx-get` links from item 5 — no changes needed

## References
TODO.md Phase 2, item 7

## Test plan
- 18 new tests in `tests/test_ui.py` using Flask test client
- Covers: 200 responses, empty states, transaction data rendering, invalid month format (400), default-to-current-month, prev/next navigation links, year boundary wrap (Jan→Dec, Dec→Jan)
- Full suite: 344 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)