### PR TITLE
Fix ON DELETE semantics: cascade → no-action on structural FKs

### DIFF
--- a/db/migrations/002_create_data_imports_table.sql
+++ b/db/migrations/002_create_data_imports_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE data_imports (
     account_id INTEGER NOT NULL,
     filename TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
+    FOREIGN KEY (account_id) REFERENCES accounts(id)
 );
 
 -- Create index for faster lookups by account

--- a/db/migrations/004_create_transactions_table.sql
+++ b/db/migrations/004_create_transactions_table.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     additional_metadata TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (account_id) REFERENCES accounts(id),
-    FOREIGN KEY (data_import_id) REFERENCES data_imports(id) ON DELETE CASCADE,
+    FOREIGN KEY (data_import_id) REFERENCES data_imports(id),
     FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL,
     FOREIGN KEY (auto_category_id) REFERENCES categories(id) ON DELETE SET NULL
 );

--- a/tests/repositories/test_structural_fks.py
+++ b/tests/repositories/test_structural_fks.py
@@ -1,0 +1,91 @@
+"""Tests for NO ACTION FK constraints on structural references.
+
+Covers:
+- data_imports.account_id → accounts(id)
+- transactions.data_import_id → data_imports(id)
+"""
+
+import sqlite3
+from datetime import date
+
+import pytest
+
+from models.transaction import Transaction
+
+
+def _make_transaction(account_id, data_import_id, raw_suffix="1"):
+    t = Transaction.create_with_checksum(
+        raw_data=f"row_{raw_suffix}",
+        account_id=account_id,
+        transaction_date=date(2025, 1, 15),
+        post_date=None,
+        description="Test",
+        bank_category=None,
+        amount=100,
+        transaction_type="expense",
+    )
+    t.data_import_id = data_import_id
+    return t
+
+
+class TestStructuralForeignKeys:
+    """Verify NO ACTION (block) semantics on structural FK columns."""
+
+    def test_delete_account_with_data_imports_raises(self, services):
+        """Deleting an account that has dependent data_imports must fail."""
+        account = services.accounts.create("a", "bofa", "A")
+        services.data_imports.create(account.id, "test.csv.gz")
+
+        with services.db_manager.connect() as conn:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute("DELETE FROM accounts WHERE id = ?", (account.id,))
+
+    def test_delete_data_import_with_transactions_raises(self, services):
+        """Deleting a data_import that has dependent transactions must fail."""
+        account = services.accounts.create("a", "bofa", "A")
+        di = services.data_imports.create(account.id, "test.csv.gz")
+        t = _make_transaction(account.id, di.id)
+        services.transactions.create(t)
+
+        with services.db_manager.connect() as conn:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute("DELETE FROM data_imports WHERE id = ?", (di.id,))
+
+    def test_delete_account_with_no_data_imports_succeeds(self, services):
+        """Deleting an account with zero data_imports succeeds."""
+        account = services.accounts.create("a", "bofa", "A")
+
+        with services.db_manager.connect() as conn:
+            conn.execute("DELETE FROM accounts WHERE id = ?", (account.id,))
+            row = conn.execute(
+                "SELECT id FROM accounts WHERE id = ?", (account.id,)
+            ).fetchone()
+        assert row is None
+
+    def test_delete_data_import_with_no_transactions_succeeds(self, services):
+        """Deleting a data_import with zero transactions succeeds."""
+        account = services.accounts.create("a", "bofa", "A")
+        di = services.data_imports.create(account.id, "test.csv.gz")
+
+        with services.db_manager.connect() as conn:
+            conn.execute("DELETE FROM data_imports WHERE id = ?", (di.id,))
+            row = conn.execute(
+                "SELECT id FROM data_imports WHERE id = ?", (di.id,)
+            ).fetchone()
+        assert row is None
+
+    def test_unblock_path_transaction_then_data_import_then_account(self, services):
+        """Removing dependents in order allows the parent deletes to succeed."""
+        account = services.accounts.create("a", "bofa", "A")
+        di = services.data_imports.create(account.id, "test.csv.gz")
+        t = _make_transaction(account.id, di.id)
+        services.transactions.create(t)
+
+        with services.db_manager.connect() as conn:
+            conn.execute("DELETE FROM transactions WHERE id = ?", (t.id,))
+            conn.execute("DELETE FROM data_imports WHERE id = ?", (di.id,))
+            conn.execute("DELETE FROM accounts WHERE id = ?", (account.id,))
+
+            assert conn.execute("SELECT COUNT(*) FROM transactions").fetchone()[0] == 0
+            assert conn.execute("SELECT COUNT(*) FROM data_imports").fetchone()[0] == 0
+            assert conn.execute("SELECT COUNT(*) FROM accounts").fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- Removes `ON DELETE CASCADE` from `data_imports.account_id` (migration 002) — now defaults to `NO ACTION`
- Removes `ON DELETE CASCADE` from `transactions.data_import_id` (migration 004) — now defaults to `NO ACTION`
- Adds `tests/repositories/test_structural_fks.py` with 5 tests covering blocked deletes and the unblock path

These two FKs previously chained into a silent footgun: `DELETE FROM accounts` would wipe all data_imports and all their transactions. The `NO ACTION` default blocks such deletes loudly with an `IntegrityError` until dependents are removed first.

## References
Closes #43

## Test plan
- `uv run pytest tests/repositories/test_structural_fks.py -v` — 5 new tests all pass
- `uv run pytest tests/` — full suite of 355 tests passes
- **Existing dev databases must be recreated** after this merges (`/reset` or delete the data dir and re-run migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)