### PR TITLE
Add web-based transaction import flow with inline review

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,9 +1,12 @@
 """Flask application factory."""
 
 from flask import Flask, render_template
+from flask_wtf.csrf import CSRFProtect
 
 from config import load_config
 from services.base import Services
+
+csrf = CSRFProtect()
 
 
 def create_app(config=None, services=None):
@@ -25,7 +28,11 @@ def create_app(config=None, services=None):
         services = Services(config)
 
     app.config["NECKER_CONFIG"] = config
+    app.config["SECRET_KEY"] = config.secret_key
+    app.config["MAX_CONTENT_LENGTH"] = 5 * 1024 * 1024  # 5 MB upload limit
     app.services = services
+
+    csrf.init_app(app)
 
     # Register blueprints
     from app.api import api_bp
@@ -37,5 +44,17 @@ def create_app(config=None, services=None):
     @app.route("/")
     def index():
         return render_template("base.html")
+
+    @app.errorhandler(413)
+    def request_entity_too_large(e):
+        return (
+            render_template(
+                "fragments/import_form.html",
+                accounts=[],
+                error="File too large. Maximum upload size is 5 MB.",
+                selected_account_id=None,
+            ),
+            413,
+        )
 
     return app

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,9 +3,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <title>{% block title %}Necker{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
   <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener('htmx:configRequest', function(e) {
+      var token = document.querySelector('meta[name="csrf-token"]');
+      if (token) {
+        e.detail.headers['X-CSRFToken'] = token.content;
+      }
+    });
+  </script>
 </head>
 <body>
   <header>
@@ -14,6 +23,7 @@
       <a hx-get="/ui/transactions" hx-target="#content" hx-push-url="true">Transactions</a>
       <a hx-get="/ui/accounts" hx-target="#content" hx-push-url="true">Accounts</a>
       <a hx-get="/ui/categories" hx-target="#content" hx-push-url="true">Categories</a>
+      <a hx-get="/ui/imports/new" hx-target="#content" hx-push-url="true">Import</a>
     </nav>
   </header>
 

--- a/app/templates/fragments/import_form.html
+++ b/app/templates/fragments/import_form.html
@@ -1,0 +1,25 @@
+{% if error %}
+<p><strong>Error:</strong> {{ error }}</p>
+{% endif %}
+<section>
+  <h2>Import Transactions</h2>
+  {% if accounts %}
+  <form hx-post="/ui/imports" hx-target="#content" hx-encoding="multipart/form-data">
+    <label for="account_id">Account</label>
+    <select name="account_id" id="account_id" required>
+      <option value="">Select account...</option>
+      {% for account in accounts %}
+      <option value="{{ account.id }}"
+        {% if selected_account_id == account.id %}selected{% endif %}>
+        {{ account.name }} ({{ account.account_type }})
+      </option>
+      {% endfor %}
+    </select>
+    <label for="csv_file">CSV File</label>
+    <input type="file" name="csv_file" id="csv_file" accept=".csv" required>
+    <button type="submit">Import</button>
+  </form>
+  {% else %}
+  <p>No accounts found. <a hx-get="/ui/accounts" hx-target="#content" hx-push-url="true">Create an account</a> first.</p>
+  {% endif %}
+</section>

--- a/app/templates/fragments/import_review.html
+++ b/app/templates/fragments/import_review.html
@@ -1,0 +1,65 @@
+<section>
+  <h2>Review Import{% if account %} — {{ account.name }}{% endif %}</h2>
+  {% if result %}
+  <p>
+    Imported {{ result.inserted }} transaction{{ 's' if result.inserted != 1 else '' }}
+    ({{ result.skipped }} duplicate{{ 's' if result.skipped != 1 else '' }} skipped,
+    {{ result.categorized }} auto-categorized).
+    Review and adjust categories and merchant names below, then click Save.
+  </p>
+  {% endif %}
+  <form hx-post="/ui/imports/{{ data_import_id }}/review" hx-target="#content">
+    <table>
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Description</th>
+          <th>Amount</th>
+          <th>Auto-category</th>
+          <th>Category</th>
+          <th>Merchant</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for t in transactions %}
+        {% set pending = edits.get(t.id, {}) %}
+        {% set pending_cat = pending.get('category_id', '') %}
+        {% set pending_merchant = pending.get('merchant_name', '') %}
+        <tr>
+          <td>{{ t.transaction_date.isoformat() }}</td>
+          <td>{{ t.description }}</td>
+          <td>${{ "%.2f"|format(t.amount / 100) }}</td>
+          <td>
+            {% if t.auto_category_id and t.auto_category_id in categories_map %}
+              <em>{{ categories_map[t.auto_category_id] }}</em>
+            {% endif %}
+          </td>
+          <td>
+            <select name="category_id_{{ t.id }}">
+              <option value="">-- None --</option>
+              {% for c in categories %}
+              <option value="{{ c.id }}"
+                {% if pending_cat and pending_cat == c.id|string %}selected
+                {% elif not pending_cat and t.auto_category_id == c.id %}selected{% endif %}>
+                {{ c.name }}
+              </option>
+              {% endfor %}
+            </select>
+            {% if row_errors.get(t.id, {}).get('category') %}
+            <span style="color:red"> {{ row_errors[t.id]['category'] }}</span>
+            {% endif %}
+          </td>
+          <td>
+            <input type="text" name="merchant_name_{{ t.id }}"
+              value="{{ pending_merchant if pending_merchant else (t.auto_merchant_name or '') }}">
+            {% if row_errors.get(t.id, {}).get('merchant') %}
+            <span style="color:red"> {{ row_errors[t.id]['merchant'] }}</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <button type="submit">Save changes</button>
+  </form>
+</section>

--- a/app/templates/fragments/import_success.html
+++ b/app/templates/fragments/import_success.html
@@ -1,0 +1,29 @@
+<section>
+  <h2>Import Complete</h2>
+  {% if mode == 'review' %}
+  <p>Updated {{ result.updated }} transaction{{ 's' if result.updated != 1 else '' }}.</p>
+  {% else %}
+  {% if result.parsed == 0 %}
+  <p>No transactions found in the CSV file.</p>
+  {% elif result.inserted == 0 %}
+  <p>
+    {{ result.parsed }} transaction{{ 's' if result.parsed != 1 else '' }} parsed —
+    all were duplicates and skipped.
+  </p>
+  {% else %}
+  <p>
+    Imported {{ result.inserted }} transaction{{ 's' if result.inserted != 1 else '' }}
+    ({{ result.skipped }} duplicate{{ 's' if result.skipped != 1 else '' }} skipped,
+    {{ result.categorized }} auto-categorized).
+  </p>
+  {% endif %}
+  {% endif %}
+  {% if transactions_url %}
+  <p>
+    <a hx-get="{{ transactions_url }}" hx-target="#content" hx-push-url="true">
+      View {{ month_str }} transactions &rarr;
+    </a>
+  </p>
+  {% endif %}
+  <p><a hx-get="/ui/imports/new" hx-target="#content" hx-push-url="true">Import more transactions</a></p>
+</section>

--- a/app/templates/fragments/transaction_list.html
+++ b/app/templates/fragments/transaction_list.html
@@ -7,6 +7,7 @@
     <strong>{{ month_label }}</strong>
     <a hx-get="/ui/transactions?month={{ next_month }}" hx-target="#content">{{ next_month }} &rarr;</a>
   </nav>
+  <p><button hx-get="/ui/imports/new" hx-target="#content" hx-push-url="true">Import transactions</button></p>
 
   {% if transactions %}
   <table>

--- a/app/ui/routes.py
+++ b/app/ui/routes.py
@@ -1,6 +1,8 @@
 """UI route definitions — server-rendered HTML fragments for htmx."""
 
+import tempfile
 from datetime import date
+from pathlib import Path
 
 from flask import render_template, request, current_app
 
@@ -83,3 +85,202 @@ def accounts():
 def categories():
     all_categories = current_app.services.categories.find_all()
     return render_template("fragments/category_list.html", categories=all_categories)
+
+
+@ui_bp.route("/imports/new")
+def import_form():
+    all_accounts = current_app.services.accounts.find_all()
+    return render_template(
+        "fragments/import_form.html",
+        accounts=all_accounts,
+        error=None,
+        selected_account_id=None,
+    )
+
+
+@ui_bp.route("/imports", methods=["POST"])
+def import_upload():
+    from services.ingestion import ingest_csv
+
+    # Validate account_id
+    account_id_str = request.form.get("account_id", "").strip()
+    try:
+        account_id = int(account_id_str)
+    except ValueError:
+        all_accounts = current_app.services.accounts.find_all()
+        return (
+            render_template(
+                "fragments/import_form.html",
+                accounts=all_accounts,
+                error="Please select an account.",
+                selected_account_id=None,
+            ),
+            400,
+        )
+
+    account = current_app.services.accounts.find(account_id)
+    if account is None:
+        all_accounts = current_app.services.accounts.find_all()
+        return (
+            render_template(
+                "fragments/import_form.html",
+                accounts=all_accounts,
+                error="Account not found.",
+                selected_account_id=None,
+            ),
+            404,
+        )
+
+    # Validate file upload
+    file = request.files.get("csv_file")
+    if not file or not file.filename:
+        all_accounts = current_app.services.accounts.find_all()
+        return (
+            render_template(
+                "fragments/import_form.html",
+                accounts=all_accounts,
+                error="Please select a CSV file.",
+                selected_account_id=account_id,
+            ),
+            400,
+        )
+
+    # Save to temp directory and ingest
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = Path(tmpdir) / file.filename
+        file.save(str(csv_path))
+
+        try:
+            result = ingest_csv(csv_path, account, current_app.services)
+        except ValueError as e:
+            all_accounts = current_app.services.accounts.find_all()
+            return (
+                render_template(
+                    "fragments/import_form.html",
+                    accounts=all_accounts,
+                    error=str(e),
+                    selected_account_id=account_id,
+                ),
+                400,
+            )
+        except Exception:
+            all_accounts = current_app.services.accounts.find_all()
+            return (
+                render_template(
+                    "fragments/import_form.html",
+                    accounts=all_accounts,
+                    error="An unexpected error occurred during import. Please try again.",
+                    selected_account_id=account_id,
+                ),
+                500,
+            )
+
+    # If no new transactions, skip review
+    if result["parsed"] == 0 or result["inserted"] == 0:
+        return render_template(
+            "fragments/import_success.html",
+            result=result,
+            account=account,
+            transactions_url=None,
+            month_str=None,
+            mode="upload",
+        )
+
+    # Fetch just-imported transactions for review
+    transactions = current_app.services.transactions.find_by_data_import_id(
+        result["data_import_id"]
+    )
+    all_categories = current_app.services.categories.find_all()
+    categories_map = {c.id: c.name for c in all_categories}
+
+    return render_template(
+        "fragments/import_review.html",
+        transactions=transactions,
+        account=account,
+        categories=all_categories,
+        categories_map=categories_map,
+        result=result,
+        data_import_id=result["data_import_id"],
+        edits={},
+        row_errors={},
+    )
+
+
+@ui_bp.route("/imports/<int:data_import_id>/review", methods=["POST"])
+def import_review(data_import_id):
+    transactions = current_app.services.transactions.find_by_data_import_id(
+        data_import_id
+    )
+    if not transactions:
+        all_accounts = current_app.services.accounts.find_all()
+        return (
+            render_template(
+                "fragments/import_form.html",
+                accounts=all_accounts,
+                error="No transactions found for this import.",
+                selected_account_id=None,
+            ),
+            404,
+        )
+
+    all_categories = current_app.services.categories.find_all()
+    valid_category_ids = {c.id for c in all_categories}
+    categories_map = {c.id: c.name for c in all_categories}
+
+    # Parse form data and validate
+    edits = {}
+    row_errors = {}
+
+    for txn in transactions:
+        cat_val = request.form.get(f"category_id_{txn.id}", "").strip()
+        merchant_val = request.form.get(f"merchant_name_{txn.id}", "").strip()
+        edits[txn.id] = {"category_id": cat_val, "merchant_name": merchant_val}
+
+        if cat_val:
+            try:
+                cat_id = int(cat_val)
+                if cat_id not in valid_category_ids:
+                    row_errors.setdefault(txn.id, {})["category"] = (
+                        "Invalid category selected."
+                    )
+            except ValueError:
+                row_errors.setdefault(txn.id, {})["category"] = "Invalid category."
+
+    if row_errors:
+        account = current_app.services.accounts.find(transactions[0].account_id)
+        return (
+            render_template(
+                "fragments/import_review.html",
+                transactions=transactions,
+                account=account,
+                categories=all_categories,
+                categories_map=categories_map,
+                result=None,
+                data_import_id=data_import_id,
+                edits=edits,
+                row_errors=row_errors,
+            ),
+            400,
+        )
+
+    # Apply edits to transaction objects and batch update
+    for txn in transactions:
+        edit = edits[txn.id]
+        txn.category_id = int(edit["category_id"]) if edit["category_id"] else None
+        txn.merchant_name = edit["merchant_name"] or None
+
+    updated_count = current_app.services.transactions.batch_update(
+        transactions, ["category_id", "merchant_name"]
+    )
+
+    earliest_date = min(t.transaction_date for t in transactions)
+    month_str = f"{earliest_date.year:04d}/{earliest_date.month:02d}"
+
+    return render_template(
+        "fragments/import_success.html",
+        result={"updated": updated_count},
+        account=None,
+        transactions_url=f"/ui/transactions?month={month_str}",
+        month_str=month_str,
+        mode="review",
+    )

--- a/config.py
+++ b/config.py
@@ -3,8 +3,9 @@
 Reads configuration from ~/.config/necker.toml and creates default config if needed.
 """
 
+import secrets
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import tomllib
 import tomli_w
 
@@ -26,6 +27,8 @@ class Config:
     llm_provider: str  # "openai", "ollama", etc.
     llm_openai_api_key: str
     llm_openai_model: str
+    # Web settings
+    secret_key: str = field(default_factory=lambda: secrets.token_hex(32))
 
     @property
     def db_path(self) -> Path:
@@ -109,7 +112,10 @@ def load_config() -> Config:
     llm_openai_api_key = openai_config.get("api_key", "")
     llm_openai_model = openai_config.get("model", "gpt-4o-mini")
 
-    return Config(
+    web_config = data.get("web", {})
+    secret_key = web_config.get("secret_key", "")
+
+    config = Config(
         base_dir=base_dir,
         db_data_dir=db_data_dir,
         db_filename=db_filename,
@@ -122,7 +128,14 @@ def load_config() -> Config:
         llm_provider=llm_provider,
         llm_openai_api_key=llm_openai_api_key,
         llm_openai_model=llm_openai_model,
+        secret_key=secret_key if secret_key else secrets.token_hex(32),
     )
+
+    # Persist generated secret_key so it survives restarts
+    if not secret_key:
+        _write_config(config)
+
+    return config
 
 
 def _write_config(config: Config) -> None:
@@ -159,6 +172,9 @@ def _write_config(config: Config) -> None:
                 "api_key": config.llm_openai_api_key,
                 "model": config.llm_openai_model,
             },
+        },
+        "web": {
+            "secret_key": config.secret_key,
         },
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pyyaml>=6.0.0",
     "python-dateutil>=2.8.0",
     "flask>=3.0.0",
+    "flask-wtf>=1.2.0",
 ]
 
 [dependency-groups]

--- a/repositories/transactions.py
+++ b/repositories/transactions.py
@@ -281,6 +281,29 @@ class TransactionRepository:
 
             return [self._row_to_transaction(row) for row in rows]
 
+    def find_by_data_import_id(self, data_import_id: int) -> List[Transaction]:
+        """Return all transactions belonging to a given data import.
+
+        Args:
+            data_import_id: The data import ID to filter by.
+
+        Returns:
+            List of Transaction objects ordered by transaction_date ascending, then id.
+            Empty list if no transactions exist for this data import.
+        """
+        with self.db_manager.connect() as conn:
+            cursor = conn.execute(
+                f"""
+                SELECT {_TRANSACTION_SELECT_FIELDS}
+                FROM transactions
+                WHERE data_import_id = ?
+                ORDER BY transaction_date ASC, id
+                """,
+                (data_import_id,),
+            )
+            rows = cursor.fetchall()
+            return [self._row_to_transaction(row) for row in rows]
+
     def find_historical_for_categorization(
         self, account_id: int, limit: int = 200
     ) -> List[Transaction]:

--- a/tests/repositories/test_find_by_data_import.py
+++ b/tests/repositories/test_find_by_data_import.py
@@ -1,0 +1,65 @@
+"""Tests for TransactionRepository.find_by_data_import_id."""
+
+from datetime import date
+
+from models.transaction import Transaction
+
+
+def _make_transaction(account_id, data_import_id, raw_suffix, txn_date=None):
+    t = Transaction.create_with_checksum(
+        raw_data=f"fdi_row_{raw_suffix}",
+        account_id=account_id,
+        transaction_date=txn_date or date(2025, 3, 15),
+        post_date=None,
+        description=f"Transaction {raw_suffix}",
+        bank_category=None,
+        amount=1000,
+        transaction_type="expense",
+    )
+    t.data_import_id = data_import_id
+    return t
+
+
+class TestFindByDataImportId:
+    def test_returns_transactions_for_import(self, services):
+        account = services.accounts.create("test", "bofa", "Test")
+        di = services.data_imports.create(account.id, None)
+        t1 = services.transactions.create(_make_transaction(account.id, di.id, "a"))
+        t2 = services.transactions.create(_make_transaction(account.id, di.id, "b"))
+
+        result = services.transactions.find_by_data_import_id(di.id)
+        result_ids = {t.id for t in result}
+
+        assert t1.id in result_ids
+        assert t2.id in result_ids
+
+    def test_returns_empty_list_for_unknown_import(self, services):
+        result = services.transactions.find_by_data_import_id(99999)
+        assert result == []
+
+    def test_excludes_transactions_from_other_imports(self, services):
+        account = services.accounts.create("test2", "bofa", "Test2")
+        di1 = services.data_imports.create(account.id, None)
+        di2 = services.data_imports.create(account.id, None)
+
+        t1 = services.transactions.create(_make_transaction(account.id, di1.id, "x"))
+        services.transactions.create(_make_transaction(account.id, di2.id, "y"))
+
+        result = services.transactions.find_by_data_import_id(di1.id)
+        assert len(result) == 1
+        assert result[0].id == t1.id
+
+    def test_ordered_by_transaction_date_ascending(self, services):
+        account = services.accounts.create("test3", "bofa", "Test3")
+        di = services.data_imports.create(account.id, None)
+
+        t_later = services.transactions.create(
+            _make_transaction(account.id, di.id, "later", date(2025, 3, 20))
+        )
+        t_earlier = services.transactions.create(
+            _make_transaction(account.id, di.id, "earlier", date(2025, 3, 10))
+        )
+
+        result = services.transactions.find_by_data_import_id(di.id)
+        assert result[0].id == t_earlier.id
+        assert result[1].id == t_later.id

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,60 @@
+"""Tests for configuration loading, including secret_key generation and persistence."""
+
+import tomllib
+
+from config import Config, load_config, _write_config
+
+
+class TestSecretKey:
+    def test_default_config_generates_secret_key(self):
+        config = Config.default()
+        assert config.secret_key
+        assert len(config.secret_key) == 64  # secrets.token_hex(32) → 64 hex chars
+
+    def test_two_default_configs_have_different_keys(self):
+        c1 = Config.default()
+        c2 = Config.default()
+        assert c1.secret_key != c2.secret_key
+
+    def test_load_config_generates_key_when_absent(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "necker.toml"
+        monkeypatch.setattr("config.get_config_path", lambda: config_path)
+
+        config = load_config()
+        assert config.secret_key
+        assert len(config.secret_key) == 64
+
+    def test_load_config_persists_generated_key(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "necker.toml"
+        monkeypatch.setattr("config.get_config_path", lambda: config_path)
+
+        config = load_config()
+
+        # Read the written TOML and verify secret_key is present
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["web"]["secret_key"] == config.secret_key
+
+    def test_load_config_reuses_existing_key(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "necker.toml"
+        monkeypatch.setattr("config.get_config_path", lambda: config_path)
+
+        # First load generates and persists
+        config1 = load_config()
+        key1 = config1.secret_key
+
+        # Second load should reuse the persisted key
+        config2 = load_config()
+        assert config2.secret_key == key1
+
+    def test_write_config_includes_secret_key(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "necker.toml"
+        monkeypatch.setattr("config.get_config_path", lambda: config_path)
+
+        config = Config.default()
+        config.secret_key = "my-test-secret-key"
+        _write_config(config)
+
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["web"]["secret_key"] == "my-test-secret-key"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,5 +1,7 @@
 """Tests for the UI blueprint routes."""
 
+import csv
+import io
 from datetime import date
 
 import pytest
@@ -9,11 +11,28 @@ from models.transaction import Transaction
 from services.base import Services
 
 
+def _make_bofa_csv_bytes(rows):
+    """Create a BofA-format CSV as bytes for upload tests."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["Description", "", "Summary Amt."])
+    writer.writerow(["Beginning balance as of 01/01/2024", "", "1000.00"])
+    writer.writerow(["Total credits", "", "500.00"])
+    writer.writerow(["Total debits", "", "-200.00"])
+    writer.writerow(["Ending balance as of 01/31/2024", "", "1300.00"])
+    writer.writerow([])
+    writer.writerow(["Date", "Description", "Amount", "Running Bal."])
+    for row in rows:
+        writer.writerow(row)
+    return buf.getvalue().encode()
+
+
 @pytest.fixture
 def app(test_config, db_manager_with_schema):
     svc = Services(test_config, db_manager=db_manager_with_schema)
     flask_app = create_app(config=test_config, services=svc)
     flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
     return flask_app
 
 
@@ -151,3 +170,232 @@ class TestTransactionsUI:
         # December → next should be January of next year
         html = client.get("/ui/transactions?month=2025/12").data.decode()
         assert "2026/01" in html
+
+    def test_transactions_has_import_button(self, client):
+        html = client.get("/ui/transactions?month=2025/03").data.decode()
+        assert "Import transactions" in html
+        assert "/ui/imports/new" in html
+
+
+# --- /ui/imports ---
+
+
+class TestImportUI:
+    def test_import_form_returns_200(self, client):
+        resp = client.get("/ui/imports/new")
+        assert resp.status_code == 200
+
+    def test_import_form_shows_empty_state_without_accounts(self, client):
+        html = client.get("/ui/imports/new").data.decode()
+        assert "No accounts found" in html
+
+    def test_import_form_shows_accounts(self, client, account):
+        html = client.get("/ui/imports/new").data.decode()
+        assert "bofa_checking" in html
+        assert "<select" in html
+
+    def test_import_upload_without_file_returns_400(self, client, account):
+        resp = client.post(
+            "/ui/imports",
+            data={"account_id": str(account.id)},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "Please select a CSV file" in resp.data.decode()
+
+    def test_import_upload_without_account_returns_400(self, client):
+        resp = client.post(
+            "/ui/imports",
+            data={"account_id": ""},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "Please select an account" in resp.data.decode()
+
+    def test_import_upload_unknown_account_returns_404(self, client):
+        resp = client.post(
+            "/ui/imports",
+            data={
+                "account_id": "99999",
+                "csv_file": (io.BytesIO(b"data"), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 404
+
+    def test_import_upload_valid_csv_returns_review(self, client, account):
+        csv_bytes = _make_bofa_csv_bytes(
+            [
+                ["01/15/2024", "Coffee Shop", "-5.00", "995.00"],
+                ["01/20/2024", "Salary", "2000.00", "2995.00"],
+            ]
+        )
+        resp = client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(csv_bytes), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "Review Import" in html
+        assert "Coffee Shop" in html
+        assert "Salary" in html
+
+    def test_import_upload_valid_csv_inserts_transactions(self, client, svc, account):
+        csv_bytes = _make_bofa_csv_bytes(
+            [["01/15/2024", "Coffee Shop", "-5.00", "995.00"]]
+        )
+        client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(csv_bytes), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+        txns = svc.transactions.find_by_account(account.id)
+        assert len(txns) == 1
+        assert txns[0].description == "Coffee Shop"
+
+    def test_import_upload_all_duplicates_returns_success(self, client, svc, account):
+        csv_bytes = _make_bofa_csv_bytes(
+            [["01/15/2024", "Coffee Shop", "-5.00", "995.00"]]
+        )
+        # First import
+        client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(csv_bytes), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+        # Second import — all duplicates
+        resp = client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(csv_bytes), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "Import Complete" in html
+        assert "Review Import" not in html
+
+    def test_import_upload_bad_csv_headers_returns_400(self, client, account):
+        bad_csv = b"Col1,Col2\nfoo,bar\n"
+        resp = client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(bad_csv), "bad.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "Error" in resp.data.decode()
+
+    def test_import_review_valid_edits_returns_success(self, client, svc, account):
+        csv_bytes = _make_bofa_csv_bytes(
+            [["01/15/2024", "Coffee Shop", "-5.00", "995.00"]]
+        )
+        # Upload to get data_import_id
+        upload_resp = client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(csv_bytes), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+        assert upload_resp.status_code == 200
+
+        # Get data_import_id from db
+        txns = svc.transactions.find_by_account(account.id)
+        assert len(txns) == 1
+        data_import_id = txns[0].data_import_id
+
+        resp = client.post(
+            f"/ui/imports/{data_import_id}/review",
+            data={
+                f"category_id_{txns[0].id}": "",
+                f"merchant_name_{txns[0].id}": "Starbucks",
+            },
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert resp.status_code == 200
+        assert "Import Complete" in resp.data.decode()
+
+        # Verify merchant was saved
+        updated = svc.transactions.find(txns[0].id)
+        assert updated.merchant_name == "Starbucks"
+
+    def test_import_review_invalid_category_returns_400(self, client, svc, account):
+        csv_bytes = _make_bofa_csv_bytes(
+            [["01/15/2024", "Coffee Shop", "-5.00", "995.00"]]
+        )
+        client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(csv_bytes), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+
+        txns = svc.transactions.find_by_account(account.id)
+        data_import_id = txns[0].data_import_id
+
+        resp = client.post(
+            f"/ui/imports/{data_import_id}/review",
+            data={
+                f"category_id_{txns[0].id}": "99999",
+                f"merchant_name_{txns[0].id}": "",
+            },
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert resp.status_code == 400
+        html = resp.data.decode()
+        assert "Invalid category" in html
+
+    def test_import_review_unknown_import_returns_404(self, client):
+        resp = client.post(
+            "/ui/imports/99999/review",
+            data={},
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert resp.status_code == 404
+
+    def test_import_review_saves_category(self, client, svc, account):
+        category = svc.categories.create("Food", "Food expenses", None)
+        csv_bytes = _make_bofa_csv_bytes(
+            [["01/15/2024", "Coffee Shop", "-5.00", "995.00"]]
+        )
+        client.post(
+            "/ui/imports",
+            data={
+                "account_id": str(account.id),
+                "csv_file": (io.BytesIO(csv_bytes), "test.csv"),
+            },
+            content_type="multipart/form-data",
+        )
+
+        txns = svc.transactions.find_by_account(account.id)
+        data_import_id = txns[0].data_import_id
+
+        client.post(
+            f"/ui/imports/{data_import_id}/review",
+            data={
+                f"category_id_{txns[0].id}": str(category.id),
+                f"merchant_name_{txns[0].id}": "",
+            },
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        updated = svc.transactions.find(txns[0].id)
+        assert updated.category_id == category.id

--- a/uv.lock
+++ b/uv.lock
@@ -185,6 +185,20 @@ wheels = [
 ]
 
 [[package]]
+name = "flask-wtf"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "itsdangerous" },
+    { name = "wtforms" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/9b/f1cd6e41bbf874f3436368f2c7ee3216c1e82d666ff90d1d800e20eb1317/flask_wtf-1.2.2.tar.gz", hash = "sha256:79d2ee1e436cf570bccb7d916533fa18757a2f18c290accffab1b9a0b684666b", size = 42641, upload-time = "2024-10-24T07:18:58.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/19/354449145fbebb65e7c621235b6ad69bebcfaec2142481f044d0ddc5b5c5/flask_wtf-1.2.2-py3-none-any.whl", hash = "sha256:e93160c5c5b6b571cf99300b6e01b72f9a101027cab1579901f8b10c5daf0b70", size = 12779, upload-time = "2024-10-24T07:18:56.976Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -402,6 +416,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "flask" },
+    { name = "flask-wtf" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dateutil" },
@@ -420,6 +435,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = ">=3.0.0" },
+    { name = "flask-wtf", specifier = ">=1.2.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
@@ -825,6 +841,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wtforms"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/e4/633d080897e769ed5712dcfad626e55dbd6cf45db0ff4d9884315c6a82da/wtforms-3.2.1.tar.gz", hash = "sha256:df3e6b70f3192e92623128123ec8dca3067df9cfadd43d59681e210cfb8d4682", size = 137801, upload-time = "2024-10-21T11:34:00.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/c9/2088fb5645cd289c99ebe0d4cdcc723922a1d8e1beaefb0f6f76dff9b21c/wtforms-3.2.1-py3-none-any.whl", hash = "sha256:583bad77ba1dd7286463f21e11aa3043ca4869d03575921d1a1698d0715e0fd4", size = 152454, upload-time = "2024-10-21T11:33:58.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add Flask-WTF for CSRF protection (wired globally via `CSRFProtect` in `create_app`; htmx requests carry the token via `X-CSRFToken` header injected by a `htmx:configRequest` script in `base.html`)
- Add `secret_key` to `Config`: auto-generated with `secrets.token_hex(32)` on first run, persisted to `~/.config/necker.toml` under `[web]`
- Add `MAX_CONTENT_LENGTH = 5 MB` and a friendly 413 error handler
- Add `TransactionRepository.find_by_data_import_id` — returns transactions for a given import, ordered by date ascending
- Add three new UI routes: `GET /ui/imports/new`, `POST /ui/imports` (upload + ingest), `POST /ui/imports/<id>/review` (bulk save)
- Add three new templates: `import_form.html`, `import_review.html`, `import_success.html`
- Add "Import" nav link to `base.html` and "Import transactions" button to `transaction_list.html`

## References

Closes #41

## Test plan

- `tests/repositories/test_find_by_data_import.py`: `find_by_data_import_id` returns correct rows, ordered correctly, empty list on unknown ID
- `tests/test_config.py`: secret_key generation on default config, generation + persistence on first `load_config`, reuse on subsequent loads
- `tests/test_ui.py` (new `TestImportUI` class): form renders, upload validation, valid CSV import returns review fragment, all-duplicates returns success, bad CSV headers returns 400, review save applies edits, invalid category returns 400, unknown import returns 404

All 380 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)