### PR TITLE
Add Budget entity with CLI and web UI CRUD

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,5 +1,6 @@
 """API route definitions — read-only JSON endpoints."""
 
+import sqlite3
 from datetime import date
 
 from flask import jsonify, request, current_app
@@ -178,3 +179,102 @@ def get_transaction(transaction_id):
             }
         ), 404
     return jsonify(_transaction_to_dict(transaction))
+
+
+# --- Budgets ---
+
+
+def _budget_to_dict(b) -> dict:
+    return {
+        "id": b.id,
+        "category_id": b.category_id,
+        "period_type": b.period_type,
+        "amount": b.amount,
+        "category_name": b.category_name,
+    }
+
+
+VALID_PERIOD_TYPES = {"monthly", "yearly"}
+
+
+@api_bp.route("/budgets")
+def list_budgets():
+    budgets = current_app.services.budgets.find_all()
+    return jsonify([_budget_to_dict(b) for b in budgets])
+
+
+@api_bp.route("/budgets", methods=["POST"])
+def create_budget():
+    data = request.get_json(silent=True) or {}
+    category_id = data.get("category_id")
+    period_type = data.get("period_type")
+    amount = data.get("amount")
+
+    if category_id is None or not isinstance(category_id, int):
+        return jsonify(
+            {"error": "bad_request", "message": "category_id must be an integer"}
+        ), 400
+    if period_type not in VALID_PERIOD_TYPES:
+        return jsonify(
+            {
+                "error": "bad_request",
+                "message": "period_type must be 'monthly' or 'yearly'",
+            }
+        ), 400
+    if not isinstance(amount, int) or amount <= 0:
+        return jsonify(
+            {
+                "error": "bad_request",
+                "message": "amount must be a positive integer (cents)",
+            }
+        ), 400
+
+    category = current_app.services.categories.find(category_id)
+    if category is None:
+        return jsonify(
+            {"error": "bad_request", "message": f"Category {category_id} not found"}
+        ), 400
+
+    try:
+        budget = current_app.services.budgets.create(category_id, period_type, amount)
+    except sqlite3.IntegrityError:
+        return jsonify(
+            {
+                "error": "conflict",
+                "message": "A budget for this category and period already exists",
+            }
+        ), 400
+
+    return jsonify(_budget_to_dict(budget)), 201
+
+
+@api_bp.route("/budgets/<int:budget_id>", methods=["DELETE"])
+def delete_budget(budget_id):
+    deleted = current_app.services.budgets.delete(budget_id)
+    if not deleted:
+        return jsonify(
+            {"error": "not_found", "message": f"Budget {budget_id} not found"}
+        ), 404
+    return "", 204
+
+
+@api_bp.route("/budgets/<int:budget_id>", methods=["PATCH"])
+def update_budget(budget_id):
+    data = request.get_json(silent=True) or {}
+    amount = data.get("amount")
+
+    if not isinstance(amount, int) or amount <= 0:
+        return jsonify(
+            {
+                "error": "bad_request",
+                "message": "amount must be a positive integer (cents)",
+            }
+        ), 400
+
+    budget = current_app.services.budgets.update_amount(budget_id, amount)
+    if budget is None:
+        return jsonify(
+            {"error": "not_found", "message": f"Budget {budget_id} not found"}
+        ), 404
+
+    return jsonify(_budget_to_dict(budget))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,6 +23,7 @@
       <a hx-get="/ui/transactions" hx-target="#content" hx-push-url="true">Transactions</a>
       <a hx-get="/ui/accounts" hx-target="#content" hx-push-url="true">Accounts</a>
       <a hx-get="/ui/categories" hx-target="#content" hx-push-url="true">Categories</a>
+      <a hx-get="/ui/budgets" hx-target="#content" hx-push-url="true">Budgets</a>
       <a hx-get="/ui/imports/new" hx-target="#content" hx-push-url="true">Import</a>
     </nav>
   </header>

--- a/app/templates/fragments/budget_amount_display.html
+++ b/app/templates/fragments/budget_amount_display.html
@@ -1,0 +1,1 @@
+<td id="budget-amount-{{ budget.id }}">${{ "%.2f"|format(budget.amount / 100) }}</td>

--- a/app/templates/fragments/budget_amount_edit.html
+++ b/app/templates/fragments/budget_amount_edit.html
@@ -1,0 +1,5 @@
+<form hx-patch="/ui/budgets/{{ budget.id }}" hx-target="#budget-amount-{{ budget.id }}" hx-swap="outerHTML" style="display:inline">
+  <input type="number" name="amount" value="{{ '%.2f'|format(budget.amount / 100) }}" step="0.01" min="0.01" style="width:8em" required>
+  <button type="submit">Save</button>
+  <button type="button" hx-get="/ui/budgets/{{ budget.id }}/amount" hx-target="#budget-amount-{{ budget.id }}" hx-swap="outerHTML">Cancel</button>
+</form>

--- a/app/templates/fragments/budget_form.html
+++ b/app/templates/fragments/budget_form.html
@@ -1,0 +1,25 @@
+{% if error %}
+<p><strong>Error:</strong> {{ error }}</p>
+{% endif %}
+<section>
+  <h3>New Budget</h3>
+  <form hx-post="/ui/budgets" hx-target="#content">
+    <label for="category_id">Category</label>
+    <select name="category_id" id="category_id" required>
+      <option value="">Select category...</option>
+      {% for c in categories %}
+      <option value="{{ c.id }}"{% if form_data.get('category_id') == c.id|string %} selected{% endif %}>{{ c.name }}</option>
+      {% endfor %}
+    </select>
+    <label for="period_type">Period</label>
+    <select name="period_type" id="period_type" required>
+      <option value="">Select period...</option>
+      <option value="monthly"{% if form_data.get('period_type') == 'monthly' %} selected{% endif %}>Monthly</option>
+      <option value="yearly"{% if form_data.get('period_type') == 'yearly' %} selected{% endif %}>Yearly</option>
+    </select>
+    <label for="amount">Amount (dollars)</label>
+    <input type="number" name="amount" id="amount" placeholder="500.00" step="0.01" min="0.01" required
+      value="{{ form_data.get('amount', '') }}">
+    <button type="submit">Create Budget</button>
+  </form>
+</section>

--- a/app/templates/fragments/budget_list.html
+++ b/app/templates/fragments/budget_list.html
@@ -1,0 +1,38 @@
+<section>
+  <h2>Budgets</h2>
+  <p><button hx-get="/ui/budgets/new" hx-target="#budget-form" hx-swap="innerHTML">New Budget</button></p>
+  <div id="budget-form"></div>
+  {% if error %}
+  <p><strong>Error:</strong> {{ error }}</p>
+  {% endif %}
+  {% if budgets %}
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Category</th>
+        <th>Period</th>
+        <th>Amount</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for budget in budgets %}
+      <tr id="budget-row-{{ budget.id }}">
+        <td>{{ budget.id }}</td>
+        <td>{{ budget.category_name }}</td>
+        <td>{{ budget.period_type }}</td>
+        <td id="budget-amount-{{ budget.id }}">${{ "%.2f"|format(budget.amount / 100) }}</td>
+        <td>
+          <button hx-get="/ui/budgets/{{ budget.id }}/edit" hx-target="#budget-amount-{{ budget.id }}" hx-swap="innerHTML">Edit</button>
+          <button hx-delete="/ui/budgets/{{ budget.id }}" hx-target="#budget-row-{{ budget.id }}" hx-swap="outerHTML"
+            hx-confirm="Delete this budget?">Delete</button>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>No budgets found.</p>
+  {% endif %}
+</section>

--- a/app/ui/routes.py
+++ b/app/ui/routes.py
@@ -1,5 +1,6 @@
 """UI route definitions — server-rendered HTML fragments for htmx."""
 
+import sqlite3
 import tempfile
 from datetime import date
 from pathlib import Path
@@ -323,3 +324,149 @@ def import_review(data_import_id):
         month_str=month_str,
         mode="review",
     )
+
+
+# --- Budgets ---
+
+
+@ui_bp.route("/budgets")
+def budgets():
+    all_budgets = current_app.services.budgets.find_all()
+    return render_template(
+        "fragments/budget_list.html", budgets=all_budgets, error=None
+    )
+
+
+@ui_bp.route("/budgets/new")
+def budget_new():
+    all_categories = current_app.services.categories.find_all()
+    return render_template(
+        "fragments/budget_form.html",
+        categories=all_categories,
+        error=None,
+        form_data={},
+    )
+
+
+@ui_bp.route("/budgets", methods=["POST"])
+def budget_create():
+    category_id_str = request.form.get("category_id", "").strip()
+    period_type = request.form.get("period_type", "").strip()
+    amount_str = request.form.get("amount", "").strip()
+    form_data = {
+        "category_id": category_id_str,
+        "period_type": period_type,
+        "amount": amount_str,
+    }
+    all_categories = current_app.services.categories.find_all()
+
+    try:
+        category_id = int(category_id_str)
+    except ValueError:
+        return (
+            render_template(
+                "fragments/budget_form.html",
+                categories=all_categories,
+                error="Please select a category.",
+                form_data=form_data,
+            ),
+            400,
+        )
+
+    if period_type not in ("monthly", "yearly"):
+        return (
+            render_template(
+                "fragments/budget_form.html",
+                categories=all_categories,
+                error="Period type must be 'monthly' or 'yearly'.",
+                form_data=form_data,
+            ),
+            400,
+        )
+
+    try:
+        amount_dollars = float(amount_str)
+        amount_cents = int(round(amount_dollars * 100))
+    except ValueError:
+        return (
+            render_template(
+                "fragments/budget_form.html",
+                categories=all_categories,
+                error="Amount must be a number.",
+                form_data=form_data,
+            ),
+            400,
+        )
+
+    if amount_cents <= 0:
+        return (
+            render_template(
+                "fragments/budget_form.html",
+                categories=all_categories,
+                error="Amount must be greater than zero.",
+                form_data=form_data,
+            ),
+            400,
+        )
+
+    try:
+        current_app.services.budgets.create(category_id, period_type, amount_cents)
+    except sqlite3.IntegrityError:
+        return (
+            render_template(
+                "fragments/budget_form.html",
+                categories=all_categories,
+                error="A budget for this category and period already exists.",
+                form_data=form_data,
+            ),
+            400,
+        )
+
+    all_budgets = current_app.services.budgets.find_all()
+    return render_template(
+        "fragments/budget_list.html", budgets=all_budgets, error=None
+    )
+
+
+@ui_bp.route("/budgets/<int:budget_id>", methods=["DELETE"])
+def budget_delete(budget_id):
+    current_app.services.budgets.delete(budget_id)
+    return "", 200
+
+
+@ui_bp.route("/budgets/<int:budget_id>/edit")
+def budget_edit(budget_id):
+    budget = current_app.services.budgets.find(budget_id)
+    if budget is None:
+        return "", 404
+    return render_template("fragments/budget_amount_edit.html", budget=budget)
+
+
+@ui_bp.route("/budgets/<int:budget_id>/amount")
+def budget_amount(budget_id):
+    budget = current_app.services.budgets.find(budget_id)
+    if budget is None:
+        return "", 404
+    return render_template("fragments/budget_amount_display.html", budget=budget)
+
+
+@ui_bp.route("/budgets/<int:budget_id>", methods=["PATCH"])
+def budget_update(budget_id):
+    amount_str = request.form.get("amount", "").strip()
+
+    try:
+        amount_dollars = float(amount_str)
+        amount_cents = int(round(amount_dollars * 100))
+    except ValueError:
+        budget = current_app.services.budgets.find(budget_id)
+        return render_template("fragments/budget_amount_edit.html", budget=budget), 400
+
+    if amount_cents <= 0:
+        budget = current_app.services.budgets.find(budget_id)
+        return render_template("fragments/budget_amount_edit.html", budget=budget), 400
+
+    budget = current_app.services.budgets.update_amount(budget_id, amount_cents)
+    if budget is None:
+        return "", 404
+
+    return render_template("fragments/budget_amount_display.html", budget=budget)

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -20,7 +20,7 @@ Examples:
 
 import sys
 import argparse
-from cli import accounts, transactions, migrate, categories, server
+from cli import accounts, transactions, migrate, categories, server, budgets
 from config import load_config
 from services.base import Services
 from db.manager import DatabaseManager
@@ -47,6 +47,7 @@ def main():
     accounts.setup_parser(subparsers)
     transactions.setup_parser(subparsers)
     categories.setup_parser(subparsers)
+    budgets.setup_parser(subparsers)
     migrate.setup_parser(subparsers)
     server.setup_parser(subparsers)
 
@@ -67,7 +68,13 @@ def main():
 
             # Commands that use services: accounts, transactions, categories, serve
             # Commands that use db_manager directly: migrate
-            if args.command in ("accounts", "transactions", "categories", "serve"):
+            if args.command in (
+                "accounts",
+                "transactions",
+                "categories",
+                "budgets",
+                "serve",
+            ):
                 args.func(args, services)
             elif args.command == "migrate":
                 # Migrate commands need db_manager for raw database operations

--- a/cli/budgets.py
+++ b/cli/budgets.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+
+import sys
+from logger import get_logger
+
+logger = get_logger()
+
+VALID_PERIOD_TYPES = ("monthly", "yearly")
+
+
+def _format_amount(cents: int) -> str:
+    return f"${cents / 100:.2f}"
+
+
+def cmd_list(args, services):
+    budgets = services.budgets.find_all()
+
+    if not budgets:
+        logger.info("No budgets found.")
+        return
+
+    logger.info("\nBudgets:")
+    logger.info("=" * 80)
+    logger.info(f"{'ID':<6} {'Category':<30} {'Period':<10} {'Amount':<12}")
+    logger.info("-" * 80)
+    for b in budgets:
+        logger.info(
+            f"{b.id:<6} {b.category_name:<30} {b.period_type:<10} {_format_amount(b.amount):<12}"
+        )
+    logger.info(f"\nTotal budgets: {len(budgets)}")
+
+
+def cmd_create(args, services):
+    print("\nCreate New Budget")
+    print("=" * 80)
+
+    # Pick category
+    all_categories = services.categories.find_all()
+    if not all_categories:
+        logger.error("No categories found. Create a category first.")
+        sys.exit(1)
+
+    print("\nAvailable categories:")
+    for c in all_categories:
+        print(f"  {c.id}: {c.name}")
+
+    cat_input = input("\nCategory ID: ").strip()
+    try:
+        category_id = int(cat_input)
+    except ValueError:
+        logger.error("Category ID must be a number.")
+        sys.exit(1)
+
+    category = services.categories.find(category_id)
+    if not category:
+        logger.error(f"Category with ID {category_id} not found.")
+        sys.exit(1)
+
+    # Pick period type
+    period_type = input("Period type (monthly/yearly): ").strip().lower()
+    if period_type not in VALID_PERIOD_TYPES:
+        logger.error(
+            f"Invalid period type. Must be one of: {', '.join(VALID_PERIOD_TYPES)}"
+        )
+        sys.exit(1)
+
+    # Enter amount
+    amount_input = input("Amount (in dollars, e.g. 500.00): ").strip()
+    try:
+        amount_dollars = float(amount_input)
+        amount_cents = int(round(amount_dollars * 100))
+    except ValueError:
+        logger.error("Amount must be a number.")
+        sys.exit(1)
+
+    if amount_cents <= 0:
+        logger.error("Amount must be greater than zero.")
+        sys.exit(1)
+
+    try:
+        budget = services.budgets.create(category_id, period_type, amount_cents)
+        logger.info(f"\n✓ Budget created successfully with ID: {budget.id}")
+        logger.info(f"  Category: {budget.category_name}")
+        logger.info(f"  Period: {budget.period_type}")
+        logger.info(f"  Amount: {_format_amount(budget.amount)}")
+    except Exception as e:
+        logger.error(f"Error creating budget: {e}")
+        sys.exit(1)
+
+
+def cmd_delete(args, services):
+    budget_id = args.budget_id
+
+    budget = services.budgets.find(budget_id)
+    if not budget:
+        logger.error(f"Budget with ID {budget_id} not found.")
+        sys.exit(1)
+
+    logger.info("\nBudget to delete:")
+    logger.info(f"  ID: {budget.id}")
+    logger.info(f"  Category: {budget.category_name}")
+    logger.info(f"  Period: {budget.period_type}")
+    logger.info(f"  Amount: {_format_amount(budget.amount)}")
+
+    confirm = (
+        input("\nAre you sure you want to delete this budget? (yes/no): ")
+        .strip()
+        .lower()
+    )
+    if confirm != "yes":
+        logger.info("Deletion cancelled.")
+        return
+
+    if services.budgets.delete(budget_id):
+        logger.info("✓ Budget deleted successfully.")
+    else:
+        logger.error("Failed to delete budget.")
+        sys.exit(1)
+
+
+def cmd_modify(args, services):
+    budget_id = args.budget_id
+
+    budget = services.budgets.find(budget_id)
+    if not budget:
+        logger.error(f"Budget with ID {budget_id} not found.")
+        sys.exit(1)
+
+    try:
+        amount_dollars = float(args.amount)
+        amount_cents = int(round(amount_dollars * 100))
+    except ValueError:
+        logger.error("Amount must be a number.")
+        sys.exit(1)
+
+    if amount_cents <= 0:
+        logger.error("Amount must be greater than zero.")
+        sys.exit(1)
+
+    updated = services.budgets.update_amount(budget_id, amount_cents)
+    if not updated:
+        logger.error("Failed to update budget.")
+        sys.exit(1)
+
+    logger.info("✓ Budget updated successfully.")
+    logger.info(f"  Category: {updated.category_name}")
+    logger.info(f"  Period: {updated.period_type}")
+    logger.info(f"  Amount: {_format_amount(updated.amount)}")
+
+
+def setup_parser(subparsers):
+    parser = subparsers.add_parser(
+        "budgets",
+        help="Manage budgets",
+        description="Create, list, modify, and delete spending budgets",
+    )
+
+    budgets_subparsers = parser.add_subparsers(
+        title="subcommands",
+        description="Available budget commands",
+        dest="subcommand",
+        required=True,
+    )
+
+    list_parser = budgets_subparsers.add_parser("list", help="List all budgets")
+    list_parser.set_defaults(func=cmd_list)
+
+    create_parser = budgets_subparsers.add_parser(
+        "create", help="Create a new budget interactively"
+    )
+    create_parser.set_defaults(func=cmd_create)
+
+    delete_parser = budgets_subparsers.add_parser(
+        "delete", help="Delete a budget by ID"
+    )
+    delete_parser.add_argument("budget_id", type=int, help="ID of the budget to delete")
+    delete_parser.set_defaults(func=cmd_delete)
+
+    modify_parser = budgets_subparsers.add_parser(
+        "modify", help="Modify a budget's amount"
+    )
+    modify_parser.add_argument("budget_id", type=int, help="ID of the budget to modify")
+    modify_parser.add_argument(
+        "--amount", required=True, help="New amount in dollars (e.g. 500.00)"
+    )
+    modify_parser.set_defaults(func=cmd_modify)

--- a/db/migrations/011_create_budgets_table.sql
+++ b/db/migrations/011_create_budgets_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS budgets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    category_id INTEGER NOT NULL,
+    period_type TEXT NOT NULL CHECK (period_type IN ('monthly', 'yearly')),
+    amount INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (category_id) REFERENCES categories(id),
+    UNIQUE (category_id, period_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_budgets_category_id ON budgets(category_id);

--- a/models/budget.py
+++ b/models/budget.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Budget:
+    id: int
+    category_id: int
+    period_type: str  # 'monthly' or 'yearly'
+    amount: int  # cents
+    category_name: Optional[str] = None  # populated by repository joins

--- a/repositories/budgets.py
+++ b/repositories/budgets.py
@@ -1,0 +1,78 @@
+from typing import List, Optional
+
+from models.budget import Budget
+
+
+class BudgetRepository:
+    def __init__(self, db_manager):
+        self.db_manager = db_manager
+
+    def find_all(self) -> List[Budget]:
+        with self.db_manager.connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT b.id, b.category_id, b.period_type, b.amount, c.name
+                FROM budgets b
+                JOIN categories c ON b.category_id = c.id
+                ORDER BY c.name, b.period_type
+                """
+            )
+            return [
+                Budget(
+                    id=row[0],
+                    category_id=row[1],
+                    period_type=row[2],
+                    amount=row[3],
+                    category_name=row[4],
+                )
+                for row in cursor.fetchall()
+            ]
+
+    def find(self, budget_id: int) -> Optional[Budget]:
+        with self.db_manager.connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT b.id, b.category_id, b.period_type, b.amount, c.name
+                FROM budgets b
+                JOIN categories c ON b.category_id = c.id
+                WHERE b.id = ?
+                """,
+                (budget_id,),
+            )
+            row = cursor.fetchone()
+            if row:
+                return Budget(
+                    id=row[0],
+                    category_id=row[1],
+                    period_type=row[2],
+                    amount=row[3],
+                    category_name=row[4],
+                )
+            return None
+
+    def create(self, category_id: int, period_type: str, amount: int) -> Budget:
+        with self.db_manager.connect() as conn:
+            cursor = conn.execute(
+                "INSERT INTO budgets (category_id, period_type, amount) VALUES (?, ?, ?)",
+                (category_id, period_type, amount),
+            )
+            conn.commit()
+            budget_id = cursor.lastrowid
+        return self.find(budget_id)
+
+    def update_amount(self, budget_id: int, amount: int) -> Optional[Budget]:
+        with self.db_manager.connect() as conn:
+            cursor = conn.execute(
+                "UPDATE budgets SET amount = ? WHERE id = ?",
+                (amount, budget_id),
+            )
+            conn.commit()
+            if cursor.rowcount == 0:
+                return None
+        return self.find(budget_id)
+
+    def delete(self, budget_id: int) -> bool:
+        with self.db_manager.connect() as conn:
+            cursor = conn.execute("DELETE FROM budgets WHERE id = ?", (budget_id,))
+            conn.commit()
+            return cursor.rowcount > 0

--- a/services/base.py
+++ b/services/base.py
@@ -31,8 +31,10 @@ class Services:
         from repositories.transactions import TransactionRepository
         from repositories.data_imports import DataImportRepository
         from repositories.categories import CategoryRepository
+        from repositories.budgets import BudgetRepository
 
         self.accounts = AccountRepository(self.db_manager)
         self.transactions = TransactionRepository(self.db_manager)
         self.data_imports = DataImportRepository(self.db_manager)
         self.categories = CategoryRepository(self.db_manager)
+        self.budgets = BudgetRepository(self.db_manager)

--- a/tests/repositories/test_budgets.py
+++ b/tests/repositories/test_budgets.py
@@ -1,0 +1,88 @@
+"""Tests for BudgetRepository — CRUD, FK enforcement, uniqueness, check constraint."""
+
+import sqlite3
+
+import pytest
+
+
+@pytest.fixture
+def category(services):
+    return services.categories.create("Food", "Food expenses")
+
+
+@pytest.fixture
+def category2(services):
+    return services.categories.create("Transport", "Transport expenses")
+
+
+class TestBudgetCRUD:
+    def test_create_and_find(self, services, category):
+        budget = services.budgets.create(category.id, "monthly", 50000)
+        assert budget.id is not None
+        assert budget.category_id == category.id
+        assert budget.period_type == "monthly"
+        assert budget.amount == 50000
+        assert budget.category_name == category.name
+
+    def test_find_not_found(self, services):
+        assert services.budgets.find(9999) is None
+
+    def test_find_all_empty(self, services):
+        assert services.budgets.find_all() == []
+
+    def test_find_all_ordered_by_category_name(self, services, category, category2):
+        services.budgets.create(category2.id, "monthly", 10000)
+        services.budgets.create(category.id, "monthly", 20000)
+        budgets = services.budgets.find_all()
+        names = [b.category_name for b in budgets]
+        assert names == sorted(names)
+
+    def test_update_amount(self, services, category):
+        budget = services.budgets.create(category.id, "monthly", 50000)
+        updated = services.budgets.update_amount(budget.id, 75000)
+        assert updated.amount == 75000
+        assert updated.id == budget.id
+
+    def test_update_amount_not_found(self, services):
+        result = services.budgets.update_amount(9999, 50000)
+        assert result is None
+
+    def test_delete(self, services, category):
+        budget = services.budgets.create(category.id, "monthly", 50000)
+        assert services.budgets.delete(budget.id) is True
+        assert services.budgets.find(budget.id) is None
+
+    def test_delete_not_found(self, services):
+        assert services.budgets.delete(9999) is False
+
+    def test_both_period_types(self, services, category):
+        monthly = services.budgets.create(category.id, "monthly", 10000)
+        yearly = services.budgets.create(category.id, "yearly", 100000)
+        assert monthly.period_type == "monthly"
+        assert yearly.period_type == "yearly"
+        assert len(services.budgets.find_all()) == 2
+
+
+class TestBudgetConstraints:
+    def test_uniqueness_constraint(self, services, category):
+        services.budgets.create(category.id, "monthly", 50000)
+        with pytest.raises(sqlite3.IntegrityError):
+            services.budgets.create(category.id, "monthly", 60000)
+
+    def test_fk_bogus_category_raises(self, services):
+        with pytest.raises(sqlite3.IntegrityError):
+            services.budgets.create(9999, "monthly", 50000)
+
+    def test_no_action_delete_category_with_budget_raises(self, services, category):
+        services.budgets.create(category.id, "monthly", 50000)
+        with services.db_manager.connect() as conn:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute("DELETE FROM categories WHERE id = ?", (category.id,))
+
+    def test_check_constraint_invalid_period_type(self, services, category):
+        with services.db_manager.connect() as conn:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO budgets (category_id, period_type, amount) VALUES (?, ?, ?)",
+                    (category.id, "weekly", 50000),
+                )

--- a/tests/test_budget_api.py
+++ b/tests/test_budget_api.py
@@ -1,0 +1,145 @@
+"""Tests for budget API endpoints."""
+
+import pytest
+
+from app.app import create_app
+from services.base import Services
+
+
+@pytest.fixture
+def app(test_config, db_manager_with_schema):
+    svc = Services(test_config, db_manager=db_manager_with_schema)
+    flask_app = create_app(config=test_config, services=svc)
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def svc(app):
+    return app.services
+
+
+@pytest.fixture
+def category(svc):
+    return svc.categories.create("Food", "Food expenses")
+
+
+@pytest.fixture
+def budget(svc, category):
+    return svc.budgets.create(category.id, "monthly", 50000)
+
+
+class TestListBudgets:
+    def test_empty(self, client):
+        resp = client.get("/api/budgets")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+
+    def test_with_budget(self, client, budget, category):
+        resp = client.get("/api/budgets")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data) == 1
+        assert data[0]["id"] == budget.id
+        assert data[0]["category_id"] == category.id
+        assert data[0]["period_type"] == "monthly"
+        assert data[0]["amount"] == 50000
+        assert data[0]["category_name"] == category.name
+
+
+class TestCreateBudget:
+    def test_success(self, client, category):
+        resp = client.post(
+            "/api/budgets",
+            json={
+                "category_id": category.id,
+                "period_type": "monthly",
+                "amount": 30000,
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["category_id"] == category.id
+        assert data["period_type"] == "monthly"
+        assert data["amount"] == 30000
+
+    def test_missing_category_id(self, client):
+        resp = client.post(
+            "/api/budgets", json={"period_type": "monthly", "amount": 30000}
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_period_type(self, client, category):
+        resp = client.post(
+            "/api/budgets",
+            json={"category_id": category.id, "period_type": "weekly", "amount": 30000},
+        )
+        assert resp.status_code == 400
+
+    def test_zero_amount(self, client, category):
+        resp = client.post(
+            "/api/budgets",
+            json={"category_id": category.id, "period_type": "monthly", "amount": 0},
+        )
+        assert resp.status_code == 400
+
+    def test_negative_amount(self, client, category):
+        resp = client.post(
+            "/api/budgets",
+            json={"category_id": category.id, "period_type": "monthly", "amount": -100},
+        )
+        assert resp.status_code == 400
+
+    def test_bogus_category_id(self, client):
+        resp = client.post(
+            "/api/budgets",
+            json={"category_id": 9999, "period_type": "monthly", "amount": 30000},
+        )
+        assert resp.status_code == 400
+
+    def test_duplicate_raises_400(self, client, category, budget):
+        resp = client.post(
+            "/api/budgets",
+            json={
+                "category_id": category.id,
+                "period_type": "monthly",
+                "amount": 99999,
+            },
+        )
+        assert resp.status_code == 400
+        assert "already exists" in resp.get_json()["message"]
+
+
+class TestDeleteBudget:
+    def test_success(self, client, budget):
+        resp = client.delete(f"/api/budgets/{budget.id}")
+        assert resp.status_code == 204
+
+    def test_not_found(self, client):
+        resp = client.delete("/api/budgets/9999")
+        assert resp.status_code == 404
+
+
+class TestPatchBudget:
+    def test_success(self, client, budget):
+        resp = client.patch(f"/api/budgets/{budget.id}", json={"amount": 75000})
+        assert resp.status_code == 200
+        assert resp.get_json()["amount"] == 75000
+
+    def test_not_found(self, client):
+        resp = client.patch("/api/budgets/9999", json={"amount": 75000})
+        assert resp.status_code == 404
+
+    def test_zero_amount(self, client, budget):
+        resp = client.patch(f"/api/budgets/{budget.id}", json={"amount": 0})
+        assert resp.status_code == 400
+
+    def test_missing_amount(self, client, budget):
+        resp = client.patch(f"/api/budgets/{budget.id}", json={})
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- New `budgets` table (migration 011) with FK to `categories`, uniqueness on `(category_id, period_type)`, and CHECK constraint on `period_type`
- `Budget` model, `BudgetRepository` (find_all/find/create/update_amount/delete), wired into `Services` DI container
- CLI: `budgets list|create|delete <id>|modify <id> --amount <amount>`
- API: `GET/POST /api/budgets`, `DELETE/PATCH /api/budgets/<id>`
- Web UI: `/ui/budgets` page with list, create form, delete, and inline amount editing via htmx
- Budgets nav link added to base template

## References
Fixes #50

## Test plan
- 13 repository tests: CRUD happy paths, uniqueness constraint, FK enforcement (bogus category_id), NO ACTION behavior (delete category blocked by budget), CHECK constraint (invalid period_type)
- 15 API tests: all four endpoints, happy paths and error cases (400/404, duplicate, zero/negative amount, invalid period type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)