### PR TITLE
Add CLI backup command using SQLite online backup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,16 @@ uv run python -m cli migrate apply
 uv run python -m cli migrate status
 ```
 
+### Database Backup
+
+```bash
+# Write a consistent snapshot of the configured database to a new file
+uv run python -m cli backup /path/to/backup.db
+```
+
+The output path must not already exist. Uses SQLite's online backup API,
+so it's safe to run while the application is writing.
+
 ## Development
 
 ### Code Formatting

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -9,6 +9,7 @@ Commands:
     accounts     Manage accounts
     transactions Import and manage transactions
     migrate      Database migrations
+    backup       Back up the database
 
 Examples:
     python -m cli accounts list
@@ -16,11 +17,12 @@ Examples:
     python -m cli transactions ingest file.csv --account-name bofa
     python -m cli migrate status
     python -m cli migrate apply
+    python -m cli backup /path/to/backup.db
 """
 
 import sys
 import argparse
-from cli import accounts, transactions, migrate, categories, server, budgets
+from cli import accounts, transactions, migrate, categories, server, budgets, backup
 from config import load_config
 from db.manager import DatabaseManager
 from logger import setup_logging
@@ -48,6 +50,7 @@ def main():
     categories.setup_parser(subparsers)
     budgets.setup_parser(subparsers)
     migrate.setup_parser(subparsers)
+    backup.setup_parser(subparsers)
     server.setup_parser(subparsers)
 
     # Parse arguments and execute
@@ -73,8 +76,8 @@ def main():
                 "serve",
             ):
                 args.func(args, db_manager, config)
-            elif args.command == "migrate":
-                # Migrate commands need db_manager only
+            elif args.command in ("migrate", "backup"):
+                # These commands need db_manager only
                 args.func(args, db_manager)
             else:
                 args.func(args)

--- a/cli/backup.py
+++ b/cli/backup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Backup the configured database to a user-provided path."""
+
+from pathlib import Path
+
+from logger import get_logger
+
+logger = get_logger()
+
+
+def cmd_backup(args, db_manager):
+    """Back up the configured database to args.output_path."""
+    output_path = Path(args.output_path).resolve()
+    db_manager.backup_to(output_path)
+    logger.info(f"Backed up database to {output_path}")
+
+
+def setup_parser(subparsers):
+    """Setup backup subcommand parser.
+
+    Args:
+        subparsers: The subparsers object from the main CLI
+    """
+    parser = subparsers.add_parser(
+        "backup",
+        help="Back up the database",
+        description="Back up the configured database to a file using SQLite's online backup API",
+    )
+    parser.add_argument(
+        "output_path",
+        help="Path where the backup file will be written (must not already exist)",
+    )
+    parser.set_defaults(func=cmd_backup)

--- a/db/manager.py
+++ b/db/manager.py
@@ -2,6 +2,8 @@
 
 import sqlite3
 from contextlib import contextmanager
+from pathlib import Path
+
 from config import Config, get_migrations_dir
 
 
@@ -52,3 +54,29 @@ class DatabaseManager:
             Path: Path to the migrations directory.
         """
         return get_migrations_dir()
+
+    def backup_to(self, output_path: Path) -> None:
+        """Back up the configured database to output_path using SQLite's online backup API.
+
+        Raises:
+            FileNotFoundError: If the source database or the output parent directory does not exist.
+            FileExistsError: If output_path already exists.
+        """
+        db_path = self.config.db_path
+        if not db_path.exists():
+            raise FileNotFoundError(f"database does not exist: {db_path}")
+
+        if not output_path.parent.exists():
+            raise FileNotFoundError(
+                f"output directory does not exist: {output_path.parent}"
+            )
+
+        if output_path.exists():
+            raise FileExistsError(f"output path already exists: {output_path}")
+
+        with self.connect() as source:
+            dest = sqlite3.connect(output_path)
+            try:
+                source.backup(dest)
+            finally:
+                dest.close()

--- a/tests/cli/test_backup.py
+++ b/tests/cli/test_backup.py
@@ -1,0 +1,139 @@
+"""Tests for CLI backup command."""
+
+import sqlite3
+import pytest
+from argparse import Namespace
+from pathlib import Path
+
+from config import Config, get_migrations_dir
+from db.manager import DatabaseManager
+from cli.backup import cmd_backup
+from tests.helpers import run_migrations
+
+
+def _make_config(tmp_path: Path) -> Config:
+    return Config(
+        base_dir=tmp_path / "necker",
+        db_data_dir=tmp_path / "necker" / "db",
+        db_filename="test.db",
+        log_level="DEBUG",
+        log_dir=tmp_path / "necker" / "logs",
+        archive_enabled=False,
+        archive_dir=tmp_path / "necker" / "archives",
+        enable_reset=False,
+        llm_enabled=False,
+        llm_provider="openai",
+        llm_openai_api_key="",
+        llm_openai_model="gpt-4o-mini",
+    )
+
+
+def _make_populated_db_manager(tmp_path: Path) -> DatabaseManager:
+    """Create a DatabaseManager with a real file DB, migrations applied, one account inserted."""
+    config = _make_config(tmp_path)
+    db_manager = DatabaseManager(config)
+
+    with db_manager.connect() as conn:
+        run_migrations(conn, get_migrations_dir())
+        conn.execute(
+            "INSERT INTO accounts (name, account_type, description) VALUES (?, ?, ?)",
+            ("acct", "bofa", "Test"),
+        )
+        conn.commit()
+
+    return db_manager
+
+
+def test_backup_creates_file_at_output_path(tmp_path):
+    db_manager = _make_populated_db_manager(tmp_path)
+    out = tmp_path / "backup.db"
+
+    args = Namespace(output_path=str(out))
+    cmd_backup(args, db_manager)
+
+    assert out.exists()
+
+
+def test_backup_contents_match_source(tmp_path):
+    db_manager = _make_populated_db_manager(tmp_path)
+    out = tmp_path / "backup.db"
+
+    args = Namespace(output_path=str(out))
+    cmd_backup(args, db_manager)
+
+    # Open the backup as a plain sqlite DB and confirm our row survived.
+    conn = sqlite3.connect(out)
+    try:
+        cursor = conn.execute("SELECT name, account_type FROM accounts")
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [("acct", "bofa")]
+
+
+def test_backup_schema_matches_source(tmp_path):
+    db_manager = _make_populated_db_manager(tmp_path)
+    out = tmp_path / "backup.db"
+
+    args = Namespace(output_path=str(out))
+    cmd_backup(args, db_manager)
+
+    with db_manager.connect() as source:
+        source_tables = {
+            row[0]
+            for row in source.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+
+    backup_conn = sqlite3.connect(out)
+    try:
+        backup_tables = {
+            row[0]
+            for row in backup_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    finally:
+        backup_conn.close()
+
+    assert backup_tables == source_tables
+
+
+def test_backup_errors_when_output_exists(tmp_path):
+    db_manager = _make_populated_db_manager(tmp_path)
+    out = tmp_path / "existing.db"
+    out.write_bytes(b"not really a db")
+
+    args = Namespace(output_path=str(out))
+    with pytest.raises(FileExistsError):
+        cmd_backup(args, db_manager)
+
+
+def test_backup_errors_when_parent_missing(tmp_path):
+    db_manager = _make_populated_db_manager(tmp_path)
+    out = tmp_path / "nope" / "backup.db"
+
+    args = Namespace(output_path=str(out))
+    with pytest.raises(FileNotFoundError):
+        cmd_backup(args, db_manager)
+
+
+def test_backup_errors_when_source_db_missing(tmp_path):
+    # Build a config whose db_path doesn't exist and never ran migrations.
+    config = _make_config(tmp_path)
+    db_manager = DatabaseManager(config)
+    out = tmp_path / "backup.db"
+
+    args = Namespace(output_path=str(out))
+    with pytest.raises(FileNotFoundError):
+        cmd_backup(args, db_manager)
+
+
+def test_backup_refuses_to_overwrite_source(tmp_path):
+    db_manager = _make_populated_db_manager(tmp_path)
+    # Point output at the source db itself — caught by the "already exists" check.
+    args = Namespace(output_path=str(db_manager.config.db_path))
+    with pytest.raises(FileExistsError):
+        cmd_backup(args, db_manager)


### PR DESCRIPTION
## Summary
- Adds `uv run python -m cli backup <output_path>` — writes a consistent snapshot of the configured database to a new file.
- Uses `sqlite3.Connection.backup()`, so it's safe against concurrent writers.
- Refuses to overwrite an existing file or write into a missing directory; surfaces a missing source DB clearly.

## References
Fixes #56

## Test plan
- [x] `uv run pytest tests/cli/test_backup.py -v` — 7 new tests covering success, schema/content parity with source, and each error path (output exists, parent missing, source missing, output == source).
- [x] `uv run pytest tests/` — full suite: 441 passed.
- [x] `uv run ruff format .` / `uv run ruff check .` — clean.
- [x] `uv run python -m cli backup --help` — help text renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)